### PR TITLE
Support register a new client by team token

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,12 @@ $ ./usque register
 ```
 
 > [!TIP]
-> If you want to specify a name for the device, you may do so by specifying `-n desiredname`.
+> If you want to specify a name for the device, you may do so by specifying `-n <device-name>`.
+
+> [!TIP]
+> If you want to register with ZeroTrust, you need to obtain the team token and do so by specifying `--jwt <team-token>`.
+> 1. Visit `https://<team-domain>/warp` and complete the authentication process.
+> 2. Obtain the team token from the success page's source code, or execute the following command in the browser console: `console.log(document.querySelector("meta[http-equiv='refresh']").content.split("=")[2])`.
 
 If you didn't get rate-limited or any other error, you should see a `Successful registration` message and a working config. In case of certain issues such as rate limiting, you may need to wait a bit and try again.
 
@@ -308,7 +313,7 @@ Example config:
 
 In my view ZeroTrust is Cloudflare's enterprise version of WARP. Explaining this in depth would be beyond the scope of this README.
 
-While the tool won't be able to log you in to ZeroTrust *(as SSO is required for login there)* practice shows that you can get connection working if you really want to. For that you need to put together a config file manually. I suggest using the `register` command to obtain a personal WARP config. Keep all fields unchanged except for `access_token` and `id`. As for how to obtain these, be creative. For example both of these can be carved out from `/var/lib/cloudflare-warp/reg.json` if using the official WARP client on Linux. Or existing device IDs are listed in the ZeroTrust dashboard. Once these are in place, you can use the `enroll` command to refresh the config with the new data. You will see that the `license` field is empty. This is normal. ZeroTrust doesn't use licenses *(to my knowledge)*.
+While the tool won't be able to log you in to ZeroTrust *(as SSO is required for login there)* practice shows that you can get connection working if you really want to. For that you need to run `./usque register --jwt <jwt>` or put together a config file manually. If you choose to put together a config file manually, I suggest using the `register` command to obtain a personal WARP config. Keep all fields unchanged except for `access_token` and `id`. As for how to obtain these, be creative. For example both of these can be carved out from `/var/lib/cloudflare-warp/reg.json` if using the official WARP client on Linux. Or existing device IDs are listed in the ZeroTrust dashboard. Once these are in place, you can use the `enroll` command to refresh the config with the new data. You will see that the `license` field is empty. This is normal. ZeroTrust doesn't use licenses *(to my knowledge)*.
 
 Warp to warp communication is supported by all modes of this tool if you have it [correctly set up](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/private-net/warp-to-warp/). Proxies and tunnels can reach services exposed on other devices and [port forwarding](#port-forwarding-mode-for-advanced-users-cross-platform) can be used to forward ports to and from the WARP network.
 

--- a/api/cloudflare.go
+++ b/api/cloudflare.go
@@ -20,7 +20,8 @@ import (
 //
 // Parameters:
 //   - model: string - The device model string to register. (e.g., "PC")
-//   - locale: string - The user's locale (e.g., "en-US").
+//   - locale: string - The user's locale. (e.g., "en-US")
+//   - jwt: string - Team token to register.
 //   - acceptTos: bool - Whether the user accepts the Terms of Service (TOS). If false, the user will be prompted to accept.
 //
 // Returns:
@@ -29,11 +30,11 @@ import (
 //
 // Example:
 //
-//	account, err := Register("PC", "en-US", false)
+//	account, err := Register("PC", "en-US", "", false)
 //	if err != nil {
 //	    log.Fatalf("Registration failed: %v", err)
 //	}
-func Register(model, locale string, acceptTos bool) (models.AccountData, error) {
+func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, error) {
 	wgKey, err := internal.GenerateRandomWgPubkey()
 	if err != nil {
 		return models.AccountData{}, fmt.Errorf("failed to generate wg key: %v", err)
@@ -79,6 +80,10 @@ func Register(model, locale string, acceptTos bool) (models.AccountData, error) 
 
 	for k, v := range internal.Headers {
 		req.Header.Set(k, v)
+	}
+
+	if jwt != "" {
+		req.Header.Set("CF-Access-Jwt-Assertion", jwt)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -51,9 +51,18 @@ var registerCmd = &cobra.Command{
 			log.Fatalf("Failed to get model: %v", err)
 		}
 
-		log.Printf("Registering with locale %s and model %s", locale, model)
+		jwt, err := cmd.Flags().GetString("jwt")
+		if err != nil {
+			log.Fatalf("Failed to get jwt: %v", err)
+		}
 
-		accountData, err := api.Register(model, locale, false)
+		if (jwt != "") {
+			log.Printf("Registering with locale %s and model %s using jwt authentication", locale, model)
+		} else {
+			log.Printf("Registering with locale %s and model %s", locale, model)
+		}
+
+		accountData, err := api.Register(model, locale, jwt, false)
 		if err != nil {
 			log.Fatalf("Failed to register: %v", err)
 		}
@@ -101,5 +110,6 @@ func init() {
 	registerCmd.Flags().StringP("locale", "l", internal.DefaultLocale, "locale")
 	registerCmd.Flags().StringP("model", "m", internal.DefaultModel, "model")
 	registerCmd.Flags().StringP("name", "n", "", "device name")
+	registerCmd.Flags().String("jwt", "", "team token")
 	rootCmd.AddCommand(registerCmd)
 }


### PR DESCRIPTION
1. Obtain the team token from `https://<team-domain>/warp`
2. Run `usque register --jwt <team-token>`