### PR TITLE
ci: Add darwin target to goreleaser

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -57,6 +57,22 @@ builds:
       - "-X github.com/Diniboy1123/usque/cmd.commit={{.Commit}}"
       - "-X github.com/Diniboy1123/usque/cmd.date={{.Date}}"
 
+  - id: darwin
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w"
+      - "-X github.com/Diniboy1123/usque/cmd.version={{.Tag}}"
+      - "-X github.com/Diniboy1123/usque/cmd.commit={{.Commit}}"
+      - "-X github.com/Diniboy1123/usque/cmd.date={{.Date}}"
+
 archives:
   - formats:
     - zip


### PR DESCRIPTION
This pull request updates the `goreleaser.yml` configuration to include a new build target for macOS (`darwin`) with both `arm64` and `amd64` architectures. I have successfully tested Usque on Darwin arm64 without encountering any issues.
