### PR TITLE
Refactor: Optimize Packet Handling in api/tunnel.go

### DIFF
--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -34,9 +34,10 @@ func (n *NetBuffer) New(capacity int) {
 	if capacity <= 0 {
 		panic("capacity must be greater than 0")
 	}
-	if capacity < 1280 {
-		capacity = 1280
-	}
+	// Reserved for future edit
+	//if capacity < 1280 {
+	//	capacity = 1280
+	//}
 	n.capacity = capacity
 	n.buf.New = func() interface{} {
 		return make([]byte, capacity)

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -14,15 +14,23 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 )
 
+// NetBuffer is a pool of byte slices with a fixed capacity.
+// Helps to reduce memory allocations and improve performance.
+// It uses a sync.Pool to manage the byte slices.
+// The capacity of the byte slices is set when the pool is created.
 type NetBuffer struct {
 	capacity int
 	buf      sync.Pool
 }
 
+// Get returns a byte slice from the pool.
 func (n *NetBuffer) Get() []byte {
 	return n.buf.Get().([]byte)
 }
 
+// Put places a byte slice back into the pool.
+// It checks if the capacity of the byte slice matches the pool's capacity.
+// If it doesn't match, the byte slice is not returned to the pool.
 func (n *NetBuffer) Put(buf []byte) {
 	if cap(buf) != n.capacity {
 		return
@@ -30,6 +38,8 @@ func (n *NetBuffer) Put(buf []byte) {
 	n.buf.Put(buf)
 }
 
+// New creates a new NetBuffer with the specified capacity.
+// The capacity must be greater than 0.
 func (n *NetBuffer) New(capacity int) {
 	if capacity <= 0 {
 		panic("capacity must be greater than 0")

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -14,8 +14,6 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 )
 
-var packetBufferPool *NetBuffer
-
 // NetBuffer is a pool of byte slices with a fixed capacity.
 // Helps to reduce memory allocations and improve performance.
 // It uses a sync.Pool to manage the byte slices.
@@ -158,7 +156,7 @@ func NewWaterAdapter(iface *water.Interface) TunnelDevice {
 //   - mtu: int - The MTU of the TUN device.
 //   - reconnectDelay: time.Duration - The delay between reconnect attempts.
 func MaintainTunnel(ctx context.Context, tlsConfig *tls.Config, keepalivePeriod time.Duration, initialPacketSize uint16, endpoint *net.UDPAddr, device TunnelDevice, mtu int, reconnectDelay time.Duration) {
-	packetBufferPool = NewNetBuffer(mtu)
+	packetBufferPool := NewNetBuffer(mtu)
 	for {
 		log.Printf("Establishing MASQUE connection to %s:%d", endpoint.IP, endpoint.Port)
 		udpConn, tr, ipConn, rsp, err := ConnectTunnel(


### PR DESCRIPTION
a memory optimization patch for packet handling in the `api/tunnel.go`. The changes aim to reduce memory allocations and improve performance when reading and writing packets. Below are the key updates grouped by theme:

* Buffer Pool Implementation
 Using Sync.Pool for managing reusable byte slices and initialized global buffers for packet buffer pooling. This reduces the need for frequent memory allocations.

* Refactor `TunnelDevice` interface for the function `ReadPacket` (May have conflict)
Every `ReadPacket` will create a new memory allocation for its buf, it can be reduced by put it in input parameter instead of new output
This Changes may need to be review and evaluate

*  Update Wireguard-go to latest version (Testing)
Ref: https://github.com/Diniboy1123/usque/issues/17
Need Testing.



