### PR TITLE
portfw: fix: Add missing -r flag

### DIFF
--- a/cmd/portfw.go
+++ b/cmd/portfw.go
@@ -339,5 +339,6 @@ func init() {
 	portFwCmd.Flags().DurationP("keepalive-period", "k", 30*time.Second, "Keepalive period for MASQUE connection")
 	portFwCmd.Flags().IntP("mtu", "m", 1280, "MTU for MASQUE connection")
 	portFwCmd.Flags().Uint16P("initial-packet-size", "i", 1242, "Initial packet size for MASQUE connection")
+	portFwCmd.Flags().DurationP("reconnect-delay", "r", 1*time.Second, "Delay between reconnect attempts")
 	rootCmd.AddCommand(portFwCmd)
 }


### PR DESCRIPTION
I encountered the error `Failed to get reconnect delay: flag accessed but not defined: reconnect-delay` when using the portfw feature.
Also, is it possible to support portfw for UDP as well?