### PR TITLE
ci: Add Linux mips targets

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -27,10 +27,14 @@ builds:
       - amd64
       - arm
       - arm64
+      - mips
+      - mipsle
     goarm:
       - 5
       - 6
       - 7
+    gomips:
+      - softfloat
     env:
       - CGO_ENABLED=0
     flags:


### PR DESCRIPTION
Offering prebuilt binaries for MIPS-based devices—like routers—would be highly valuable.