### PR TITLE
fix: Better IPv6 address parsing and fallback

### DIFF
--- a/api/masque.go
+++ b/api/masque.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 
@@ -59,8 +62,17 @@ func PrepareTlsConfig(privKey *ecdsa.PrivateKey, peerPubKey *ecdsa.PublicKey, ce
 			}
 
 			if !cert.PublicKey.(*ecdsa.PublicKey).Equal(peerPubKey) {
-				// reason is incorrect, but the best I could figure
-				// detail explains the actual reason
+				// Log fingerprints of presented and expected public keys to help debugging
+				var presentedFp, expectedFp string
+				if b, err := x509.MarshalPKIXPublicKey(cert.PublicKey); err == nil {
+					sum := sha256.Sum256(b)
+					presentedFp = hex.EncodeToString(sum[:])
+				}
+				if b2, err := x509.MarshalPKIXPublicKey(peerPubKey); err == nil {
+					sum := sha256.Sum256(b2)
+					expectedFp = hex.EncodeToString(sum[:])
+				}
+				log.Printf("TLS public key pinning mismatch: presented=%s expected=%s", presentedFp, expectedFp)
 
 				//10 is NoValidChains, but we support go1.22 where it's not defined
 				return x509.CertificateInvalidError{Cert: cert, Reason: 10, Detail: "remote endpoint has a different public key than what we trust in config.json"}

--- a/api/masque.go
+++ b/api/masque.go
@@ -73,7 +73,7 @@ func PrepareTlsConfig(privKey *ecdsa.PrivateKey, peerPubKey *ecdsa.PublicKey, ce
 					expectedFp = hex.EncodeToString(sum[:])
 				}
 				log.Printf("TLS public key pinning mismatch: presented=%s expected=%s", presentedFp, expectedFp)
-
+				// reason is incorrect, but the best I could figure
 				//10 is NoValidChains, but we support go1.22 where it's not defined
 				return x509.CertificateInvalidError{Cert: cert, Reason: 10, Detail: "remote endpoint has a different public key than what we trust in config.json"}
 			}

--- a/cmd/nativetun.go
+++ b/cmd/nativetun.go
@@ -75,19 +75,35 @@ var nativeTunCmd = &cobra.Command{
 			cmd.Printf("Failed to get connect port: %v\n", err)
 			return
 		}
+		connectPortChanged := cmd.Flags().Changed("connect-port")
 
 		var endpoint *net.UDPAddr
+		var ip net.IP
 		if ipv6, err := cmd.Flags().GetBool("ipv6"); err == nil && !ipv6 {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV4),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+			if err != nil {
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv4 and fallback IPv6: %v\n", err)
+					return
+				}
 			}
 		} else {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV6),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+			if err != nil {
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv6 and fallback IPv4: %v\n", err)
+					return
+				}
 			}
 		}
+		finalPort, err := config.GetConnectPort(true, connectPort, connectPortChanged)
+		if err != nil {
+			cmd.Printf("Failed to determine connect port: %v\n", err)
+			return
+		}
+		endpoint = &net.UDPAddr{IP: ip, Port: finalPort}
 
 		tunnelIPv4, err := cmd.Flags().GetBool("no-tunnel-ipv4")
 		if err != nil {

--- a/cmd/portfw.go
+++ b/cmd/portfw.go
@@ -74,19 +74,35 @@ var portFwCmd = &cobra.Command{
 			cmd.Printf("Failed to get connect port: %v\n", err)
 			return
 		}
+		connectPortChanged := cmd.Flags().Changed("connect-port")
 
 		var endpoint *net.UDPAddr
+		var ip net.IP
 		if ipv6, err := cmd.Flags().GetBool("ipv6"); err == nil && !ipv6 {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV4),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+			if err != nil {
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv4 and fallback IPv6: %v\n", err)
+					return
+				}
 			}
 		} else {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV6),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+			if err != nil {
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv6 and fallback IPv4: %v\n", err)
+					return
+				}
 			}
 		}
+		finalPort, err := config.GetConnectPort(true, connectPort, connectPortChanged)
+		if err != nil {
+			cmd.Printf("Failed to determine connect port: %v\n", err)
+			return
+		}
+		endpoint = &net.UDPAddr{IP: ip, Port: finalPort}
 
 		tunnelIPv4, err := cmd.Flags().GetBool("no-tunnel-ipv4")
 		if err != nil {

--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -83,19 +83,38 @@ var socksCmd = &cobra.Command{
 			cmd.Printf("Failed to get connect port: %v\n", err)
 			return
 		}
+		connectPortChanged := cmd.Flags().Changed("connect-port")
 
 		var endpoint *net.UDPAddr
+		var ip net.IP
 		if ipv6, err := cmd.Flags().GetBool("ipv6"); err == nil && !ipv6 {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV4),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+			if err != nil {
+				// fallback to IPv6 endpoint if IPv4 is missing or unparsable
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv4 and fallback IPv6: %v\n", err)
+					return
+				}
 			}
 		} else {
-			endpoint = &net.UDPAddr{
-				IP:   net.ParseIP(config.AppConfig.EndpointV6),
-				Port: connectPort,
+			ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV6)
+			if err != nil {
+				// fallback to IPv4 endpoint if IPv6 is missing or unparsable
+				ip, err = config.ParseIPFromEndpoint(config.AppConfig.EndpointV4)
+				if err != nil {
+					cmd.Printf("Failed to parse endpoint IPv6 and fallback IPv4: %v\n", err)
+					return
+				}
 			}
 		}
+		// determine final port (prefer CLI if provided, otherwise config)
+		finalPort, err := config.GetConnectPort(true, connectPort, connectPortChanged)
+		if err != nil {
+			cmd.Printf("Failed to determine connect port: %v\n", err)
+			return
+		}
+		endpoint = &net.UDPAddr{IP: ip, Port: finalPort}
 
 		tunnelIPv4, err := cmd.Flags().GetBool("no-tunnel-ipv4")
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
+	"strings"
 )
 
 // Config represents the application configuration structure, containing essential details such as keys, endpoints, and access tokens.
@@ -15,6 +18,8 @@ type Config struct {
 	PrivateKey     string `json:"private_key"`      // Base64-encoded ECDSA private key
 	EndpointV4     string `json:"endpoint_v4"`      // IPv4 address of the endpoint
 	EndpointV6     string `json:"endpoint_v6"`      // IPv6 address of the endpoint
+	EndpointV4Port string `json:"endpoint_v4_port"` // Optional port for IPv4 endpoint
+	EndpointV6Port string `json:"endpoint_v6_port"` // Optional port for IPv6 endpoint
 	EndpointPubKey string `json:"endpoint_pub_key"` // PEM-encoded ECDSA public key of the endpoint to verify against
 	License        string `json:"license"`          // Application license key
 	ID             string `json:"id"`               // Device unique identifier
@@ -117,4 +122,66 @@ func (*Config) GetEcEndpointPublicKey() (*ecdsa.PublicKey, error) {
 	}
 
 	return ecPubKey, nil
+}
+
+// ParseIPFromEndpoint attempts to extract a plain IP from a configuration endpoint string.
+// It accepts the following common formats and returns a net.IP when successful:
+//   - plain IP: "1.2.3.4" or "2606:..."
+//   - IP with port: "1.2.3.4:443"
+//   - bracketed IPv6 with port: "[2606:...]:443"
+//   - bracketed IPv6 without port: "[2606:...]"
+//
+// Returns an error when no valid IP can be parsed.
+func ParseIPFromEndpoint(endpoint string) (net.IP, error) {
+	// Try direct parse first (covers plain IPv4 and IPv6)
+	if ip := net.ParseIP(endpoint); ip != nil {
+		return ip, nil
+	}
+
+	// Try SplitHostPort which handles "[ipv6]:port" and "ipv4:port"
+	host := endpoint
+	if strings.Contains(endpoint, ":") {
+		if h, _, err := net.SplitHostPort(endpoint); err == nil {
+			host = h
+		} else {
+			// If SplitHostPort failed, try trimming brackets (in case it's "[ip]" or similar)
+			host = strings.Trim(endpoint, "[]")
+		}
+	}
+
+	host = strings.Trim(host, "[]")
+	if ip := net.ParseIP(host); ip != nil {
+		return ip, nil
+	}
+
+	return nil, fmt.Errorf("failed to parse IP from endpoint: %s", endpoint)
+}
+
+// GetConnectPort returns the port to use for MASQUE connection.
+// Priority:
+// 1. CLI provided port (if cliChanged is true)
+// 2. Config endpoint_v6_port or endpoint_v4_port depending on useIPv6
+// 3. cliPort (fallback)
+func GetConnectPort(useIPv6 bool, cliPort int, cliChanged bool) (int, error) {
+	if cliChanged {
+		return cliPort, nil
+	}
+	if useIPv6 {
+		if AppConfig.EndpointV6Port != "" {
+			p, err := strconv.Atoi(AppConfig.EndpointV6Port)
+			if err != nil {
+				return 0, fmt.Errorf("invalid endpoint_v6_port: %v", err)
+			}
+			return p, nil
+		}
+	} else {
+		if AppConfig.EndpointV4Port != "" {
+			p, err := strconv.Atoi(AppConfig.EndpointV4Port)
+			if err != nil {
+				return 0, fmt.Errorf("invalid endpoint_v4_port: %v", err)
+			}
+			return p, nil
+		}
+	}
+	return cliPort, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -149,7 +149,8 @@ func ParseIPFromEndpoint(endpoint string) (net.IP, error) {
 		}
 	}
 
-	host = strings.Trim(host, "[]")
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
 	if ip := net.ParseIP(host); ip != nil {
 		return ip, nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -129,8 +129,8 @@ func (*Config) GetEcEndpointPublicKey() (*ecdsa.PublicKey, error) {
 //   - plain IP: "1.2.3.4" or "2606:..."
 //   - IP with port: "1.2.3.4:443"
 //   - bracketed IPv6 with port: "[2606:...]:443"
-//   - bracketed IPv6 without port: "[2606:...]"
-//
+//   - bracketed IPv6 without port: "[2606:...]" which this goes through default port 443  to connect
+// 
 // Returns an error when no valid IP can be parsed.
 func ParseIPFromEndpoint(endpoint string) (net.IP, error) {
 	// Try direct parse first (covers plain IPv4 and IPv6)


### PR DESCRIPTION
Since the project didn't support ipv6 and port perfectly and had some bugs, I have made these changes to fix those. 

Previously if you use ipv6 the value that is being set is null value

and give you error below 

`2025/10/10 13:38:54 Establishing MASQUE connection to <nil>:443`

and also in many situations applications use different ipv6 formats like below that should be supported :

```
2606:4700:103::1
[2606:4700:103::1]
[2606:4700:103::1]:port
```
Also, we saw that defining   a different option to set the port would be really better, and we don't have issues with defining port with ipv6 if we use method 2 of showing the ipv6. 

As I'm a developer of a program called oblivion which you can find in GitHub, and we provide warp GUI for people we found love issues and tried to fix as we can :)

I home the merge request help you, and you merge it, so everyone can use.



The third problem we saw in code, and we tried to fix was the log that TLS handshake fails was incomplete and sometimes with some endpoints happens, and it's because of the invalid token and or one of the keys 

we fix the issue to check that, so the log below won't happen 

`time=2025-10-10T14:20:00.508211361-05:00 level=INFO msg="Failed to connect tunnel: CRYPTO_ERROR 0x128 (remote): tls: handshake failure"`

--In the Name of Freedom
