### PR TITLE
nativetun: Modify create/close for TUN Windows device

### DIFF
--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -60,10 +60,12 @@ func NewNetBuffer(capacity int) *NetBuffer {
 // TunnelDevice abstracts a TUN device so that we can use the same tunnel-maintenance code
 // regardless of the underlying implementation.
 type TunnelDevice interface {
-	// ReadPacket reads a packet from the device (using the given mtu) and returns its contents.
+	// Reads a packet from the device (using the given mtu) and returns its contents.
 	ReadPacket(buf []byte) (int, error)
-	// WritePacket writes a packet to the device.
+	// Writes a packet to the device.
 	WritePacket(pkt []byte) error
+	// Сloses the tunnel device.
+	Close() error
 }
 
 // NetstackAdapter wraps a tun.Device (e.g. from netstack) to satisfy TunnelDevice.
@@ -98,6 +100,10 @@ func (n *NetstackAdapter) WritePacket(pkt []byte) error {
 	// Write expects a slice of packet buffers.
 	_, err := n.dev.Write([][]byte{pkt}, 0)
 	return err
+}
+
+func (n *NetstackAdapter) Close() error {
+	return n.dev.Close()
 }
 
 // NewNetstackAdapter creates a new NetstackAdapter.
@@ -136,6 +142,10 @@ func (w *WaterAdapter) ReadPacket(buf []byte) (int, error) {
 func (w *WaterAdapter) WritePacket(pkt []byte) error {
 	_, err := w.iface.Write(pkt)
 	return err
+}
+
+func (w *WaterAdapter) Close() error {
+	return w.iface.Close()
 }
 
 // NewWaterAdapter creates a new WaterAdapter.

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -262,6 +262,8 @@ func MaintainTunnel(ctx context.Context, tlsConfig *tls.Config, keepalivePeriod 
 		}()
 
 		select {
+		case <-ctx.Done():
+			return
 		case err = <-errChan:
 			log.Printf("Tunnel connection lost: %v. Reconnecting...", err)
 			ipConn.Close()

--- a/cmd/httpproxy.go
+++ b/cmd/httpproxy.go
@@ -213,10 +213,14 @@ var httpProxyCmd = &cobra.Command{
 			}),
 		}
 
-		log.Printf("HTTP proxy listening on %s:%s\n", bindAddress, port)
-		if err := server.ListenAndServe(); err != nil {
-			cmd.Printf("Failed to start HTTP proxy: %v\n", err)
-		}
+		go func() {
+			log.Printf("HTTP proxy listening on %s:%s\n", bindAddress, port)
+			if err := server.ListenAndServe(); err != nil {
+				cmd.Printf("Failed to start HTTP proxy: %v\n", err)
+			}
+		}()
+
+		internal.WaitTerminateSignal()
 	},
 }
 

--- a/cmd/httpproxy.go
+++ b/cmd/httpproxy.go
@@ -194,7 +194,10 @@ var httpProxyCmd = &cobra.Command{
 
 		resolver := internal.GetProxyResolver(localDNS, tunNet, dnsAddrs, dnsTimeout)
 
-		go api.MaintainTunnel(context.Background(), tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go api.MaintainTunnel(ctx, tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
 
 		server := &http.Server{
 			Addr: net.JoinHostPort(bindAddress, port),

--- a/cmd/nativetun.go
+++ b/cmd/nativetun.go
@@ -153,7 +153,10 @@ var nativeTunCmd = &cobra.Command{
 
 		log.Printf("Created TUN device: %s", t.name)
 
-		go api.MaintainTunnel(context.Background(), tlsConfig, keepalivePeriod, initialPacketSize, endpoint, dev, mtu, reconnectDelay)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go api.MaintainTunnel(ctx, tlsConfig, keepalivePeriod, initialPacketSize, endpoint, dev, mtu, reconnectDelay)
 
 		log.Println("Tunnel established, you may now set up routing and DNS")
 

--- a/cmd/nativetun.go
+++ b/cmd/nativetun.go
@@ -149,6 +149,7 @@ var nativeTunCmd = &cobra.Command{
 			log.Println("Are you root/administrator? TUN device creation usually requires elevated privileges.")
 			log.Fatalf("Failed to create TUN device: %v", err)
 		}
+		defer dev.Close()
 
 		log.Printf("Created TUN device: %s", t.name)
 

--- a/cmd/nativetun.go
+++ b/cmd/nativetun.go
@@ -157,7 +157,7 @@ var nativeTunCmd = &cobra.Command{
 
 		log.Println("Tunnel established, you may now set up routing and DNS")
 
-		select {}
+		internal.WaitTerminateSignal()
 	},
 }
 

--- a/cmd/nativetun_windows.go
+++ b/cmd/nativetun_windows.go
@@ -4,6 +4,8 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"net"
 
 	"github.com/Diniboy1123/usque/api"
 	"github.com/Diniboy1123/usque/config"
@@ -34,28 +36,37 @@ func (t *tunDevice) create() (api.TunnelDevice, error) {
 		return nil, err
 	}
 
+	luid, err := internal.AliasToLuid(t.name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get LUID: %v", err)
+	}
+
 	if t.ipv4 {
-		err = internal.SetIPv4Address(t.name, config.AppConfig.IPv4, "32")
+		err = internal.AddIpAddress(luid, net.ParseIP(config.AppConfig.IPv4))
 		if err != nil {
 			return nil, fmt.Errorf("failed to set IPv4 address: %v", err)
 		}
+		log.Println("IPv4 address set successfully:", config.AppConfig.IPv4)
 
-		err = internal.SetIPv4MTU(t.name, t.mtu)
+		err = internal.SetMTU(luid, windows.AF_INET, t.mtu)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set IPv4 MTU: %v", err)
 		}
+		log.Println("IPv4 MTU set successfully:", t.mtu)
 	}
 
 	if t.ipv6 {
-		err = internal.SetIPv6Address(t.name, config.AppConfig.IPv6, "128")
+		err = internal.AddIpAddress(luid, net.ParseIP(config.AppConfig.IPv6))
 		if err != nil {
 			return nil, fmt.Errorf("failed to set IPv6 address: %v", err)
 		}
+		log.Println("IPv6 address set successfully:", config.AppConfig.IPv6)
 
-		err = internal.SetIPv6MTU(t.name, t.mtu)
+		err = internal.SetMTU(luid, windows.AF_INET6, t.mtu)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set IPv6 MTU: %v", err)
 		}
+		log.Println("IPv6 MTU set successfully:", t.mtu)
 	}
 
 	return api.NewNetstackAdapter(dev), nil

--- a/cmd/nativetun_windows.go
+++ b/cmd/nativetun_windows.go
@@ -8,18 +8,23 @@ import (
 	"github.com/Diniboy1123/usque/api"
 	"github.com/Diniboy1123/usque/config"
 	"github.com/Diniboy1123/usque/internal"
+	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/tun"
 )
 
 var longDescription = "Expose Warp as a native TUN device that accepts any IP traffic." +
 	" Requires wintun.dll and administrator rights."
 
+var (
+	tunGUID = &windows.GUID{Data1: 0x52FF161B, Data2: 0x974F, Data3: 0x11F0, Data4: [8]byte{0xAB, 0xBE, 0x5E, 0xAC, 0x1D, 0x44, 0xE7, 0x8E}}
+)
+
 func (t *tunDevice) create() (api.TunnelDevice, error) {
 	if t.name == "" {
 		t.name = "usque"
 	}
 
-	dev, err := tun.CreateTUN(t.name, t.mtu)
+	dev, err := tun.CreateTUNWithRequestedGUID(t.name, tunGUID, t.mtu)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nativetun_windows.go
+++ b/cmd/nativetun_windows.go
@@ -17,16 +17,12 @@ import (
 var longDescription = "Expose Warp as a native TUN device that accepts any IP traffic." +
 	" Requires wintun.dll and administrator rights."
 
-var (
-	tunGUID = &windows.GUID{Data1: 0x52FF161B, Data2: 0x974F, Data3: 0x11F0, Data4: [8]byte{0xAB, 0xBE, 0x5E, 0xAC, 0x1D, 0x44, 0xE7, 0x8E}}
-)
-
 func (t *tunDevice) create() (api.TunnelDevice, error) {
 	if t.name == "" {
 		t.name = "usque"
 	}
 
-	dev, err := tun.CreateTUNWithRequestedGUID(t.name, tunGUID, t.mtu)
+	dev, err := tun.CreateTUNWithRequestedGUID(t.name, internal.NameToGuid(t.name), t.mtu)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nativetun_windows.go
+++ b/cmd/nativetun_windows.go
@@ -35,7 +35,7 @@ func (t *tunDevice) create() (api.TunnelDevice, error) {
 	}
 
 	if t.ipv4 {
-		err = internal.SetIPv4Address(t.name, config.AppConfig.IPv4, "255.255.255.255")
+		err = internal.SetIPv4Address(t.name, config.AppConfig.IPv4, "32")
 		if err != nil {
 			return nil, fmt.Errorf("failed to set IPv4 address: %v", err)
 		}

--- a/cmd/portfw.go
+++ b/cmd/portfw.go
@@ -189,7 +189,10 @@ var portFwCmd = &cobra.Command{
 		}
 		defer tunDev.Close()
 
-		go api.MaintainTunnel(context.Background(), tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go api.MaintainTunnel(ctx, tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
 
 		log.Printf("Virtual tunnel created, forwarding ports")
 

--- a/cmd/portfw.go
+++ b/cmd/portfw.go
@@ -213,26 +213,28 @@ var portFwCmd = &cobra.Command{
 			}(pm)
 		}
 
-		// One packet must be sent in order to listen for incoming packets
-		// a ping may suffice as well, but we will use a simple GET request
-		client := &http.Client{
-			Transport: &http.Transport{
-				DialContext: tunNet.DialContext,
-			},
-		}
-		resp, err := client.Get("https://cloudflareok.com/test")
-		if err != nil {
-			cmd.Printf("Failed to make request to cloudflare.com: %v\n", err)
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != 204 {
-			cmd.Printf("Failed to make request to cloudflare.com: %s\n", resp.Status)
-			return
-		}
-		log.Println("Successfully connected to Cloudflare")
+		go func() {
+			// One packet must be sent in order to listen for incoming packets
+			// a ping may suffice as well, but we will use a simple GET request
+			client := &http.Client{
+				Transport: &http.Transport{
+					DialContext: tunNet.DialContext,
+				},
+			}
+			resp, err := client.Get("https://cloudflareok.com/test")
+			if err != nil {
+				cmd.Printf("Failed to make request to cloudflare.com: %v\n", err)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 204 {
+				cmd.Printf("Failed to make request to cloudflare.com: %s\n", resp.Status)
+				return
+			}
+			log.Println("Successfully connected to Cloudflare")
+		}()
 
-		select {}
+		internal.WaitTerminateSignal()
 	},
 }
 

--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -223,11 +223,15 @@ var socksCmd = &cobra.Command{
 			)
 		}
 
-		log.Printf("SOCKS proxy listening on %s:%s", bindAddress, port)
-		if err := server.ListenAndServe("tcp", net.JoinHostPort(bindAddress, port)); err != nil {
-			cmd.Printf("Failed to start SOCKS proxy: %v\n", err)
-			return
-		}
+		go func() {
+			log.Printf("SOCKS proxy listening on %s:%s", bindAddress, port)
+			if err := server.ListenAndServe("tcp", net.JoinHostPort(bindAddress, port)); err != nil {
+				cmd.Printf("Failed to start SOCKS proxy: %v\n", err)
+				return
+			}
+		}()
+
+		internal.WaitTerminateSignal()
 	},
 }
 

--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -186,7 +186,10 @@ var socksCmd = &cobra.Command{
 		}
 		defer tunDev.Close()
 
-		go api.MaintainTunnel(context.Background(), tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go api.MaintainTunnel(ctx, tlsConfig, keepalivePeriod, initialPacketSize, endpoint, api.NewNetstackAdapter(tunDev), mtu, reconnectDelay)
 
 		var resolver socks5.NameResolver
 		if localDNS {

--- a/internal/syscall_windows.go
+++ b/internal/syscall_windows.go
@@ -1,0 +1,195 @@
+//go:build windows
+
+package internal
+
+import (
+	"net"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	iphlpapi                            = windows.NewLazySystemDLL("iphlpapi.dll")
+	procConvertInterfaceAliasToLuid     = iphlpapi.NewProc("ConvertInterfaceAliasToLuid")
+	procInitializeUnicastIpAddressEntry = iphlpapi.NewProc("InitializeUnicastIpAddressEntry")
+	procCreateUnicastIpAddressEntry     = iphlpapi.NewProc("CreateUnicastIpAddressEntry")
+	procGetIpInterfaceEntry             = iphlpapi.NewProc("GetIpInterfaceEntry")
+	procSetIpInterfaceEntry             = iphlpapi.NewProc("SetIpInterfaceEntry")
+)
+
+// NL_DAD_STATE enumeration
+const (
+	IpDadStateInvalid = iota
+	IpDadStateTentative
+	IpDadStateDuplicate
+	IpDadStateDeprecated
+	IpDadStatePreferred
+)
+
+// SOCKADDR_INET union (ws2ipdef.h)
+type SockAddrInet struct {
+	Family uint16
+	data   [26]byte
+}
+
+// Convert native SOCKADDR_INET to IP address
+func (addr *SockAddrInet) GetIP() net.IP {
+	switch addr.Family {
+	case windows.AF_INET:
+		var data = (*windows.RawSockaddrInet4)(unsafe.Pointer(addr))
+		return net.IP(data.Addr[:])
+	case windows.AF_INET6:
+		var data = (*windows.RawSockaddrInet6)(unsafe.Pointer(addr))
+		return net.IP(data.Addr[:])
+	default:
+		return nil
+	}
+}
+
+// Set IP address into native SOCKADDR_INET
+func (addr *SockAddrInet) SetIP(ip net.IP) {
+	if ip4 := ip.To4(); ip4 != nil {
+		dest4 := (*windows.RawSockaddrInet4)(unsafe.Pointer(addr))
+		dest4.Family = windows.AF_INET
+		copy(dest4.Addr[:], ip4)
+	} else if ip6 := ip.To16(); ip6 != nil {
+		dest6 := (*windows.RawSockaddrInet6)(unsafe.Pointer(addr))
+		dest6.Family = windows.AF_INET6
+		copy(dest6.Addr[:], ip6)
+	}
+}
+
+//	ConvertInterfaceAliasToLuid function (netioapi.h)
+//
+// The ConvertInterfaceAliasToLuid function converts an interface alias name
+// for a network interface to the locally unique identifier (LUID) for the interface.
+func AliasToLuid(name string) (uint64, error) {
+	var luid uint64 = 0
+	n := windows.StringToUTF16Ptr(name)
+	procConvertInterfaceAliasToLuid.Find()
+	code, _, _ := syscall.SyscallN(
+		procConvertInterfaceAliasToLuid.Addr(),
+		uintptr(unsafe.Pointer(n)),
+		uintptr(unsafe.Pointer(&luid)),
+	)
+	if code != 0 {
+		return luid, windows.Errno(code)
+	}
+	return luid, nil
+}
+
+// MIB_UNICASTIPADDRESS_ROW structure (netioapi.h)
+type MibUnicastIpAddressRow struct {
+	Address            SockAddrInet
+	_                  [4]byte
+	InterfaceLuid      uint64 // IF_LUID
+	InterfaceIndex     uint32 // IF_INDEX
+	PrefixOrigin       uint32 // NL_PREFIX_ORIGIN
+	SuffixOrigin       uint32 // NL_SUFFIX_ORIGIN
+	ValidLifetime      uint32
+	PreferredLifetime  uint32
+	OnLinkPrefixLength uint8
+	SkipAsSource       bool
+	_                  [2]byte
+	DadState           uint32 // NL_DAD_STATE
+	ScopeId            uint32 // SCOPE_ID
+	CreationTimeStamp  uint64
+}
+
+//	InitializeUnicastIpAddressEntry function (netioapi.h)
+//
+// The InitializeUnicastIpAddressEntry function initializes a MIB_UNICASTIPADDRESS_ROW structure
+// with default values for a unicast IP address entry on the local computer.
+func InitializeUnicastIpAddressEntry(r *MibUnicastIpAddressRow) {
+	windows.GetVersion()
+	syscall.SyscallN(
+		procInitializeUnicastIpAddressEntry.Addr(),
+		uintptr(unsafe.Pointer(r)),
+	)
+}
+
+//	CreateUnicastIpAddressEntry function (netioapi.h)
+//
+// The CreateUnicastIpAddressEntry function adds a new unicast IP address entry on the local computer.
+func CreateUnicastIpAddressEntry(r *MibUnicastIpAddressRow) error {
+	code, _, _ := syscall.SyscallN(
+		procCreateUnicastIpAddressEntry.Addr(),
+		uintptr(unsafe.Pointer(r)),
+	)
+	if code != 0 {
+		return windows.Errno(code)
+	}
+	return nil
+}
+
+// MIB_IPINTERFACE_ROW structure (netioapi.h)
+type MibIpInterfaceRow struct {
+	Family                               uint16 // ADDRESS_FAMILY
+	_                                    [6]byte
+	InterfaceLuid                        uint64 // NET_LUID
+	InterfaceIndex                       uint32 // NET_IFINDEX
+	MaxReassemblySize                    uint32
+	InterfaceIdentifier                  uint64
+	MinRouterAdvertisementInterval       uint32
+	MaxRouterAdvertisementInterval       uint32
+	AdvertisingEnabled                   bool
+	ForwardingEnabled                    bool
+	WeakHostSend                         bool
+	WeakHostReceive                      bool
+	UseAutomaticMetric                   bool
+	UseNeighborUnreachabilityDetection   bool
+	ManagedAddressConfigurationSupported bool
+	OtherStatefulConfigurationSupported  bool
+	AdvertiseDefaultRoute                bool
+	_                                    [3]byte
+	RouterDiscoveryBehavior              uint32 // NL_ROUTER_DISCOVERY_BEHAVIOR
+	DadTransmits                         uint32
+	BaseReachableTime                    uint32
+	RetransmitTime                       uint32
+	PathMtuDiscoveryTimeout              uint32
+	LinkLocalAddressBehavior             uint32 //NL_LINK_LOCAL_ADDRESS_BEHAVIOR
+	LinkLocalAddressTimeout              uint32
+	ZoneIndices                          [16]uint32
+	SitePrefixLength                     uint32
+	Metric                               uint32
+	NlMtu                                uint32
+	Connected                            bool
+	SupportsWakeUpPatterns               bool
+	SupportsNeighborDiscovery            bool
+	SupportsRouterDiscovery              bool
+	ReachableTime                        uint32
+	TransmitOffload                      uint8 //NL_INTERFACE_OFFLOAD_ROD
+	ReceiveOffload                       uint8 //NL_INTERFACE_OFFLOAD_ROD
+	DisableDefaultRoutes                 bool
+	_                                    [1]byte
+}
+
+//	GetIpInterfaceEntry function (netioapi.h)
+//
+// The GetIpInterfaceEntry function retrieves IP information for the specified interface on the local computer.
+func GetIpInterfaceEntry(r *MibIpInterfaceRow) error {
+	code, _, _ := syscall.SyscallN(
+		procGetIpInterfaceEntry.Addr(),
+		uintptr(unsafe.Pointer(r)),
+	)
+	if code != 0 {
+		return windows.Errno(code)
+	}
+	return nil
+}
+
+//	SetIpInterfaceEntry function (netioapi.h)
+//
+// The SetIpInterfaceEntry function sets the properties of an IP interface on the local computer.
+func SetIpInterfaceEntry(r *MibIpInterfaceRow) error {
+	code, _, _ := syscall.SyscallN(
+		procSetIpInterfaceEntry.Addr(),
+		uintptr(unsafe.Pointer(r)),
+	)
+	if code != 0 {
+		return windows.Errno(code)
+	}
+	return nil
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -11,8 +11,11 @@ import (
 	"log"
 	"math/big"
 	"net"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -315,4 +318,14 @@ func CheckIfname(name string) error {
 	}
 
 	return nil
+}
+
+// Handling and waiting for SIGINT, SIGTERM, SIGHUP and SIGQUIT signals from the OS
+func WaitTerminateSignal() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+
+	<-sigChan
+	signal.Stop(sigChan)
+	close(sigChan)
 }

--- a/internal/utils_windows.go
+++ b/internal/utils_windows.go
@@ -11,7 +11,7 @@ import (
 func SetIPv4Address(ifaceName, ipAddr, mask string) error {
 	cmd := exec.Command("netsh", "interface", "ipv4", "set", "address",
 		fmt.Sprintf("name=\"%s\"", ifaceName),
-		"static", ipAddr, mask)
+		"static", ipAddr+"/"+mask)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/utils_windows.go
+++ b/internal/utils_windows.go
@@ -3,63 +3,27 @@
 package internal
 
 import (
-	"fmt"
-	"log"
-	"os/exec"
+	"net"
+	"syscall"
 )
 
-func SetIPv4Address(ifaceName, ipAddr, mask string) error {
-	cmd := exec.Command("netsh", "interface", "ipv4", "set", "address",
-		fmt.Sprintf("name=\"%s\"", ifaceName),
-		"static", ipAddr+"/"+mask)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s", output)
-	}
-
-	log.Println("IPv4 address set successfully:", ipAddr)
-	return nil
+func AddIpAddress(luid uint64, ip net.IP) error {
+	var address = &MibUnicastIpAddressRow{}
+	InitializeUnicastIpAddressEntry(address)
+	address.Address.SetIP(ip)
+	address.InterfaceLuid = luid
+	address.DadState = IpDadStatePreferred
+	return CreateUnicastIpAddressEntry(address)
 }
 
-func SetIPv6Address(ifaceName, ipAddr, mask string) error {
-	cmd := exec.Command("netsh", "interface", "ipv6", "set", "address",
-		fmt.Sprintf("interface=\"%s\"", ifaceName),
-		ipAddr+"/"+mask)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s", output)
+func SetMTU(luid uint64, family int, mtu int) error {
+	entry := &MibIpInterfaceRow{}
+	entry.Family = uint16(family)
+	entry.InterfaceLuid = luid
+	GetIpInterfaceEntry(entry)
+	if entry.Family == syscall.AF_INET {
+		entry.SitePrefixLength = 0
 	}
-
-	log.Println("IPv6 address set successfully:", ipAddr)
-	return nil
-}
-
-func SetIPv4MTU(ifaceName string, mtu int) error {
-	cmd := exec.Command("netsh", "interface", "ipv4", "set", "subinterface",
-		fmt.Sprintf("\"%s\"", ifaceName),
-		fmt.Sprintf("mtu=%d", mtu))
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s", output)
-	}
-
-	log.Println("IPv4 MTU set successfully:", mtu)
-	return nil
-}
-
-func SetIPv6MTU(ifaceName string, mtu int) error {
-	cmd := exec.Command("netsh", "interface", "ipv6", "set", "subinterface",
-		fmt.Sprintf("\"%s\"", ifaceName),
-		fmt.Sprintf("mtu=%d", mtu))
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s", output)
-	}
-
-	log.Println("IPv6 MTU set successfully:", mtu)
-	return nil
+	entry.NlMtu = uint32(mtu)
+	return SetIpInterfaceEntry(entry)
 }

--- a/internal/utils_windows.go
+++ b/internal/utils_windows.go
@@ -3,8 +3,12 @@
 package internal
 
 import (
+	"crypto/md5"
 	"net"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 func AddIpAddress(luid uint64, ip net.IP) error {
@@ -26,4 +30,16 @@ func SetMTU(luid uint64, family int, mtu int) error {
 	}
 	entry.NlMtu = uint32(mtu)
 	return SetIpInterfaceEntry(entry)
+}
+
+// NameToGuid convert TUN device name to GUID
+//
+// Parameters:
+//   - name: string - The interface name.
+//
+// Returns:
+//   - GUID: MD5 hash of name as GUID.
+func NameToGuid(name string) *windows.GUID {
+	sum := md5.Sum([]byte(name))
+	return (*windows.GUID)(unsafe.Pointer(&sum))
 }


### PR DESCRIPTION
1) An unclosed device causes the following message at the next startup: 'Removed orphaned adapter "usque 1"'.
2) Creating a wintun device with an empty GUID creates a new device with a random GUID each startup, which creates a connection with an incrementing index in "Control Panel/Network Connections".
<img width="428" height="106" alt="2" src="https://github.com/user-attachments/assets/3048a8ee-535e-40b8-88d0-9f0c4ebc359b" />

Updated: This also creates new profiles in the registry:
`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkList\Profiles`
I think 500 extra internet profiles in the system is not very good.
