### PR TITLE
cmd/enroll: nil-guard apiErr on EnrollKey failure branches

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -103,10 +103,21 @@ var enrollCmd = &cobra.Command{
 						log.Fatalf("Failed to enroll key: %v", err)
 					}
 				} else {
-					log.Fatalf("Enrollment aborted by user. API errors: %s", apiErr.ErrorsAsString("; "))
+					// Same nil guard as the outer-else branch below.
+					if apiErr != nil {
+						log.Fatalf("Enrollment aborted by user. API errors: %s", apiErr.ErrorsAsString("; "))
+					}
+					log.Fatal("Enrollment aborted by user.")
 				}
 			} else {
-				log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
+				// apiErr can be nil whenever EnrollKey failed before it
+				// got a parseable response back (e.g. a transport error),
+				// so guard the format to match the key-regen branch above
+				// and avoid the nil-pointer panic on non-API errors (#86).
+				if apiErr != nil {
+					log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
+				}
+				log.Fatalf("Failed to enroll key: %v", err)
 			}
 		}
 

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -103,17 +103,13 @@ var enrollCmd = &cobra.Command{
 						log.Fatalf("Failed to enroll key: %v", err)
 					}
 				} else {
-					// Same nil guard as the outer-else branch below.
 					if apiErr != nil {
 						log.Fatalf("Enrollment aborted by user. API errors: %s", apiErr.ErrorsAsString("; "))
 					}
 					log.Fatal("Enrollment aborted by user.")
 				}
 			} else {
-				// apiErr can be nil whenever EnrollKey failed before it
-				// got a parseable response back (e.g. a transport error),
-				// so guard the format to match the key-regen branch above
-				// and avoid the nil-pointer panic on non-API errors (#86).
+				// apiErr is nil on transport errors etc. (#86).
 				if apiErr != nil {
 					log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
 				}


### PR DESCRIPTION
## Bug

`api.EnrollKey` returns `(account, apiErr, err)` and leaves `apiErr == nil` whenever the failure happened before a parseable API response was available — a transport error, malformed response, etc. Two call sites in `cmd/enroll.go` formatted `apiErr.ErrorsAsString(...)` without a nil check and crashed the CLI:

```
panic: runtime error: invalid memory address or nil pointer dereference
    github.com/Diniboy1123/usque/models.(*APIError).ErrorsAsString(...)
        models/apierror.go:32
    github.com/Diniboy1123/usque/cmd.init.func1
        cmd/enroll.go:109
```

exactly as reported by the OpenWrt user in #86.

Fixes #86.

## Change

Both the user-abort branch and the outer-else branch now use the same `if apiErr != nil { detailed } else { plain }` split that the re-enroll retry path a few lines up already uses. No other behaviour changes — happy path and true-API-error path both take exactly the path they did before.

## Testing

- `go build ./...` passes.
- Local regression: forced `EnrollKey` to return `(nil, nil, <transport err>)`. Previously the CLI crashed on `cmd/enroll.go:109`; now it exits cleanly via `log.Fatalf("Failed to enroll key: %v", err)`.
