### PR TITLE
feat: Add the ability to set/reset WARP license key

### DIFF
--- a/api/cloudflare.go
+++ b/api/cloudflare.go
@@ -123,7 +123,7 @@ func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, er
 //	if err != nil {
 //	    log.Fatalf("Key enrollment failed: %v", err)
 //	}
-func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string) (models.AccountData, *models.APIError, error) {
+func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string) (models.AccountData, error) {
 	deviceUpdate := models.DeviceUpdate{
 		Key:     base64.StdEncoding.EncodeToString(pubKey),
 		KeyType: internal.KeyTypeMasque,
@@ -136,12 +136,12 @@ func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string)
 
 	jsonData, err := json.Marshal(deviceUpdate)
 	if err != nil {
-		return models.AccountData{}, nil, fmt.Errorf("failed to marshal json: %v", err)
+		return models.AccountData{}, fmt.Errorf("failed to marshal json: %v", err)
 	}
 
 	req, err := http.NewRequest("PATCH", internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+accountData.ID, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return models.AccountData{}, nil, fmt.Errorf("failed to create request: %v", err)
+		return models.AccountData{}, fmt.Errorf("failed to create request: %v", err)
 	}
 
 	for k, v := range internal.Headers {
@@ -151,26 +151,26 @@ func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return models.AccountData{}, nil, fmt.Errorf("failed to send request: %v", err)
+		return models.AccountData{}, fmt.Errorf("failed to send request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return models.AccountData{}, nil, fmt.Errorf("failed to read response body: %v", err)
+		return models.AccountData{}, fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		var apiErr models.APIError
 		if err := json.Unmarshal(body, &apiErr); err != nil {
-			return models.AccountData{}, nil, fmt.Errorf("failed to parse error response: %v", err)
+			return models.AccountData{}, fmt.Errorf("failed to parse error response: %v", err)
 		}
-		return models.AccountData{}, &apiErr, fmt.Errorf("failed to update: %s", resp.Status)
+		return models.AccountData{}, &apiErr
 	}
 
 	if err := json.Unmarshal(body, &accountData); err != nil {
-		return models.AccountData{}, nil, fmt.Errorf("failed to decode response: %v", err)
+		return models.AccountData{}, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	return accountData, nil, nil
+	return accountData, nil
 }

--- a/api/cloudflare.go
+++ b/api/cloudflare.go
@@ -34,24 +34,24 @@ import (
 //	if err != nil {
 //	    log.Fatalf("Registration failed: %v", err)
 //	}
-func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, error) {
+func Register(model, locale, jwt string, acceptTos bool) (*models.AccountData, error) {
 	wgKey, err := internal.GenerateRandomWgPubkey()
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to generate wg key: %v", err)
+		return nil, fmt.Errorf("failed to generate wg key: %v", err)
 	}
 	serial, err := internal.GenerateRandomAndroidSerial()
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to generate serial: %v", err)
+		return nil, fmt.Errorf("failed to generate serial: %v", err)
 	}
 
 	if !acceptTos {
 		fmt.Print("You must accept the Terms of Service (https://www.cloudflare.com/application/terms/) to register. Do you agree? (y/n): ")
 		var response string
 		if _, err := fmt.Scanln(&response); err != nil {
-			return models.AccountData{}, fmt.Errorf("failed to read user input: %v", err)
+			return nil, fmt.Errorf("failed to read user input: %v", err)
 		}
 		if response != "y" {
-			return models.AccountData{}, fmt.Errorf("user did not accept TOS")
+			return nil, fmt.Errorf("user did not accept TOS")
 		}
 	}
 
@@ -70,12 +70,12 @@ func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, er
 
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to marshal json: %v", err)
+		return nil, fmt.Errorf("failed to marshal json: %v", err)
 	}
 
 	req, err := http.NewRequest("POST", internal.ApiUrl+"/"+internal.ApiVersion+"/reg", bytes.NewBuffer(jsonData))
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
 	for k, v := range internal.Headers {
@@ -88,20 +88,29 @@ func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, er
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to send request: %v", err)
+		return nil, fmt.Errorf("failed to send request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return models.AccountData{}, fmt.Errorf("failed to register: %v", resp.Status)
+		var apiErr models.APIError
+		if err := json.Unmarshal(body, &apiErr); err != nil {
+			return nil, fmt.Errorf("failed to parse error response: %v", err)
+		}
+		return nil, &apiErr
 	}
 
 	var accountData models.AccountData
-	if err := json.NewDecoder(resp.Body).Decode(&accountData); err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to decode response: %v", err)
+	if err := json.Unmarshal(body, &accountData); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	return accountData, nil
+	return &accountData, nil
 }
 
 // EnrollKey updates an existing user account with a new MASQUE public key.
@@ -109,21 +118,22 @@ func Register(model, locale, jwt string, acceptTos bool) (models.AccountData, er
 // This function sends a PATCH request to update the user's account with a new key.
 //
 // Parameters:
-//   - accountData: models.AccountData - The account data of the user being updated.
-//   - pubKey: []byte - The new MASQUE public key in binary format.
-//   - deviceName: string - The name of the device to enroll. (optional)
+//   - deviceId: string - The device registration ID
+//   - deviceToken: string - The device registration access token
+//   - pubKey: []byte - The new MASQUE public key in binary format
+//   - deviceName: string - The name of the device to enroll (optional)
 //
 // Returns:
-//   - models.AccountData: The updated account data.
-//   - error:              An error if the update process fails.
+//   - *models.AccountData: The updated account data after key enrollment
+//   - error:              An error if the enrollment process fails
 //
 // Example:
 //
-//	updatedAccount, apiErr, err := EnrollKey(account, pubKey, "PC")
+//	updatedAccount, err := EnrollKey(deviceId, accessToken, pubKey, "MyPC")
 //	if err != nil {
 //	    log.Fatalf("Key enrollment failed: %v", err)
 //	}
-func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string) (models.AccountData, error) {
+func EnrollKey(deviceId string, deviceToken string, pubKey []byte, deviceName string) (*models.AccountData, error) {
 	deviceUpdate := models.DeviceUpdate{
 		Key:     base64.StdEncoding.EncodeToString(pubKey),
 		KeyType: internal.KeyTypeMasque,
@@ -136,41 +146,232 @@ func EnrollKey(accountData models.AccountData, pubKey []byte, deviceName string)
 
 	jsonData, err := json.Marshal(deviceUpdate)
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to marshal json: %v", err)
+		return nil, fmt.Errorf("failed to marshal json: %v", err)
 	}
 
-	req, err := http.NewRequest("PATCH", internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+accountData.ID, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("PATCH", internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+deviceId, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
 	for k, v := range internal.Headers {
 		req.Header.Set(k, v)
 	}
-	req.Header.Set("Authorization", "Bearer "+accountData.Token)
+	req.Header.Set("Authorization", "Bearer "+deviceToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to send request: %v", err)
+		return nil, fmt.Errorf("failed to send request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to read response body: %v", err)
+		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		var apiErr models.APIError
 		if err := json.Unmarshal(body, &apiErr); err != nil {
-			return models.AccountData{}, fmt.Errorf("failed to parse error response: %v", err)
+			return nil, fmt.Errorf("failed to parse error response: %v", err)
 		}
-		return models.AccountData{}, &apiErr
+		return nil, &apiErr
 	}
 
+	var accountData models.AccountData
 	if err := json.Unmarshal(body, &accountData); err != nil {
-		return models.AccountData{}, fmt.Errorf("failed to decode response: %v", err)
+		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	return accountData, nil
+	return &accountData, nil
+}
+
+// GetAccount retrieves the account information associated with the device.
+//
+// This function sends a GET request to retrieve account details including license key status,
+// account type, and other account-related information.
+//
+// Parameters:
+//   - deviceId: string - The device registration ID
+//   - deviceToken: string - The device registration access token
+//
+// Returns:
+//   - *models.Account: The account information including license key and account status
+//   - error:           An error if the request fails or account is not found
+func GetAccount(deviceId string, deviceToken string) (*models.Account, error) {
+	req, err := http.NewRequest(http.MethodGet, internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+deviceId+"/account", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	for k, v := range internal.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", "Bearer "+deviceToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr models.APIError
+		if err := json.Unmarshal(body, &apiErr); err != nil {
+			return nil, fmt.Errorf("failed to parse error response: %v", err)
+		}
+		return nil, &apiErr
+	}
+
+	var respData models.Account
+	if err := json.Unmarshal(body, &respData); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	return &respData, nil
+}
+
+// UpdateLicenceKey updates the license key associated with a device.
+//
+// This function sends a PUT request to bind a new license key to the current device.
+// The device will be associated with the WARP account linked to the provided license key.
+//
+// Parameters:
+//   - deviceId: string - The device registration ID
+//   - deviceToken: string - The device registration access token
+//   - licenceKey: string - The new license key to bind to the device
+//
+// Returns:
+//   - error: An error if the update fails or the license key is invalid
+func UpdateLicenceKey(deviceId string, deviceToken string, licenceKey string) error {
+	deviceUpdate := models.Account{
+		License: licenceKey,
+	}
+
+	jsonData, err := json.Marshal(deviceUpdate)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+deviceId+"/account", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	for k, v := range internal.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", "Bearer "+deviceToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr models.APIError
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
+			return fmt.Errorf("failed to parse error response: %v", err)
+		}
+		return &apiErr
+	}
+
+	return nil
+}
+
+// DeleteLicenceKey removes the license key associated with the device.
+//
+// This function sends a DELETE request to unbind the license key from the current device.
+// After removal, the device will no longer have WARP connectivity and the license key
+// can be used on a different device.
+//
+// Parameters:
+//   - deviceId: string - The device registration ID
+//   - deviceToken: string - The device registration access token
+//
+// Returns:
+//   - error: An error if the removal fails
+func DeleteLicenceKey(deviceId string, deviceToken string) error {
+	req, err := http.NewRequest(http.MethodDelete, internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+deviceId+"/account", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	for k, v := range internal.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", "Bearer "+deviceToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr models.APIError
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
+			return fmt.Errorf("failed to parse error response: %v", err)
+		}
+		return &apiErr
+	}
+
+	return nil
+}
+
+// GetDevices retrieves a list of all devices associated with the same license key.
+//
+// This function sends a GET request to retrieve information about all devices that share
+// the same license key binding as the current device.
+//
+// Parameters:
+//   - deviceId: string - The device registration ID
+//   - deviceToken: string - The device registration access token
+//
+// Returns:
+//   - *models.Devices: A list of devices associated with the license key
+//   - error:           An error if the request fails
+func GetDevices(deviceId string, deviceToken string) (*models.Devices, error) {
+	req, err := http.NewRequest(http.MethodGet, internal.ApiUrl+"/"+internal.ApiVersion+"/reg/"+deviceId+"/account/devices", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	for k, v := range internal.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", "Bearer "+deviceToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr models.APIError
+		if err := json.Unmarshal(body, &apiErr); err != nil {
+			return nil, fmt.Errorf("failed to parse error response: %v", err)
+		}
+		return nil, &apiErr
+	}
+
+	var respData models.Devices
+	if err := json.Unmarshal(body, &respData); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	return &respData, nil
 }

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/Diniboy1123/usque/api"
+	"github.com/Diniboy1123/usque/config"
+	"github.com/spf13/cobra"
+)
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage account and license keys",
+	Long:  "Manage account information and license key operations for WARP.",
+}
+
+var accountInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display current account information",
+	Long:  "Display detailed information about the current WARP account.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !config.ConfigLoaded {
+			log.Fatalln("Config not loaded. Please register first.")
+		}
+
+		account, err := api.GetAccount(config.AppConfig.ID, config.AppConfig.AccessToken)
+		if err != nil {
+			log.Fatalf("Failed to get account: %v\n", err)
+		}
+
+		cmd.Println("Account ID:                 ", account.ID)
+
+		if len(account.AccountType) > 0 {
+			cmd.Println("Type:                       ", account.AccountType)
+		}
+
+		if created, err := time.Parse(time.RFC3339Nano, account.Created); err == nil {
+			cmd.Println("Created:                    ", created.Format(time.DateTime))
+		}
+
+		if updated, err := time.Parse(time.RFC3339Nano, account.Updated); err == nil {
+			cmd.Println("Updated:                    ", updated.Format(time.DateTime))
+		}
+
+		if managed, err := time.Parse(time.RFC3339Nano, account.Managed); err == nil {
+			cmd.Println("Managed:                    ", managed.Format(time.DateTime))
+		}
+
+		if len(account.Organization) > 0 {
+			cmd.Println("Organization:               ", account.Organization)
+		}
+
+		cmd.Println("Role:                       ", account.Role)
+		cmd.Println("Licence Key:                ", account.License)
+
+		if account.PremiumData > 0 {
+			cmd.Println("Premium Data:               ", account.PremiumData)
+		}
+
+		if account.Quota > 0 {
+			cmd.Println("Quota:                      ", account.Quota)
+		}
+
+		if account.ReferralCount > 0 {
+			cmd.Println("Referral Count: ", account.ReferralCount)
+		}
+
+		if account.ReferralRenewalCount > 0 {
+			cmd.Println("Referral Renewal Countdown: ", account.ReferralRenewalCount)
+		}
+	},
+}
+
+var accountDevicesCmd = &cobra.Command{
+	Use:   "devices",
+	Short: "List connected devices",
+	Long:  "Display information about devices connected with the current WARP account.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !config.ConfigLoaded {
+			log.Fatalln("Config not loaded. Please register first.")
+		}
+
+		devices, err := api.GetDevices(config.AppConfig.ID, config.AppConfig.AccessToken)
+		if err != nil {
+			log.Fatalf("Failed to get devices: %v\n", err)
+			return
+		}
+
+		for index, account := range *devices {
+			cmd.Printf("Device #%d:\n", index+1)
+			cmd.Println("  ID:         ", account.ID)
+
+			if len(account.Type) > 0 {
+				cmd.Println("  Type:       ", account.Type)
+			}
+
+			if len(account.Model) > 0 {
+				cmd.Println("  Model:      ", account.Model)
+			}
+
+			if len(account.Name) > 0 {
+				cmd.Println("  Name:       ", account.Name)
+			}
+
+			if created, err := time.Parse(time.RFC3339Nano, account.Created); err == nil {
+				cmd.Println("  Created:    ", created.Format(time.DateTime))
+			}
+
+			if activated, err := time.Parse(time.RFC3339Nano, account.Activated); err == nil {
+				cmd.Println("  Activated:  ", activated.Format(time.DateTime))
+			}
+
+			cmd.Println("  Active:     ", account.Active)
+
+			if len(account.Role) > 0 {
+				cmd.Println("  Role:       ", account.Role)
+			}
+		}
+	},
+}
+
+var accountSetCmd = &cobra.Command{
+	Use:   "set <LICENSE-KEY>",
+	Short: "Set WARP license key",
+	Long: "Bind the current device to a WARP account by setting a license key.\n" +
+		"The license key must have the following format: 'xxxxxxxx-xxxxxxxx-xxxxxxxx'.",
+	Args:       cobra.MinimumNArgs(1),
+	ArgAliases: []string{"licence-key"},
+	Run: func(cmd *cobra.Command, args []string) {
+		if !config.ConfigLoaded {
+			log.Fatalln("Config not loaded. Please register first.")
+			return
+		}
+
+		if len(args) < 1 {
+			log.Fatalln("required license-key argument")
+			return
+		}
+
+		licenceKey := args[0]
+
+		err := api.UpdateLicenceKey(config.AppConfig.ID, config.AppConfig.AccessToken, licenceKey)
+		if err != nil {
+			log.Fatalf("Failed to set licence key: %v\n", err)
+		}
+
+		log.Println("Licence key successfully changed")
+	},
+}
+
+var accountResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Remove WARP license key",
+	Long: "Unbind the current device from the WARP account by removing the license key.\n" +
+		"This will free up the license key to be used on another device.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if !config.ConfigLoaded {
+			log.Fatalln("Config not loaded. Please register first.")
+		}
+
+		err := api.DeleteLicenceKey(config.AppConfig.ID, config.AppConfig.AccessToken)
+		if err != nil {
+			log.Fatalf("Failed to reset licence key: %v\n", err)
+		}
+
+		log.Println("Licence key successfully removed")
+	},
+}
+
+func init() {
+	accountCmd.AddCommand(accountInfoCmd)
+	accountCmd.AddCommand(accountSetCmd)
+	accountCmd.AddCommand(accountResetCmd)
+	accountCmd.AddCommand(accountDevicesCmd)
+	rootCmd.AddCommand(accountCmd)
+}

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -51,8 +51,13 @@ var accountInfoCmd = &cobra.Command{
 			cmd.Println("Organization:               ", account.Organization)
 		}
 
-		cmd.Println("Role:                       ", account.Role)
-		cmd.Println("Licence Key:                ", account.License)
+		if len(account.Role) > 0 {
+			cmd.Println("Role:                       ", account.Role)
+		}
+
+		if len(account.License) > 0 {
+			cmd.Println("Licence Key:                ", account.License)
+		}
 
 		if account.PremiumData > 0 {
 			cmd.Println("Premium Data:               ", account.PremiumData)

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -44,11 +44,6 @@ var enrollCmd = &cobra.Command{
 
 		log.Printf("Enrolling device key...")
 
-		accountData := models.AccountData{
-			Token: config.AppConfig.AccessToken,
-			ID:    config.AppConfig.ID,
-		}
-
 		var (
 			privKeyBytes []byte
 			publicKey    []byte
@@ -78,7 +73,7 @@ var enrollCmd = &cobra.Command{
 			}
 		}
 
-		updatedAccountData, err := api.EnrollKey(accountData, publicKey, deviceName)
+		accountData, err := api.EnrollKey(config.AppConfig.ID, config.AppConfig.AccessToken, publicKey, deviceName)
 		if err != nil {
 			if apiErr, ok := err.(models.APIError); ok && apiErr.HasErrorCode(models.InvalidPublicKey) {
 				fmt.Print("Invalid public key detected. Regenerate key? (y/n): ")
@@ -110,17 +105,16 @@ var enrollCmd = &cobra.Command{
 			PrivateKey: base64.StdEncoding.EncodeToString(privKeyBytes),
 			// TODO: proper endpoint parsing in utils
 			// strip :0
-			EndpointV4: updatedAccountData.Config.Peers[0].Endpoint.V4[:len(updatedAccountData.Config.Peers[0].Endpoint.V4)-2],
+			EndpointV4: accountData.Config.Peers[0].Endpoint.V4[:len(accountData.Config.Peers[0].Endpoint.V4)-2],
 			// strip [ from beginning and ]:0 from end
-			EndpointV6:     updatedAccountData.Config.Peers[0].Endpoint.V6[1 : len(updatedAccountData.Config.Peers[0].Endpoint.V6)-3],
+			EndpointV6:     accountData.Config.Peers[0].Endpoint.V6[1 : len(accountData.Config.Peers[0].Endpoint.V6)-3],
 			EndpointH2V4:   h2v4,
 			EndpointH2V6:   config.AppConfig.EndpointH2V6,
-			EndpointPubKey: updatedAccountData.Config.Peers[0].PublicKey,
-			License:        updatedAccountData.Account.License,
-			ID:             updatedAccountData.ID,
-			AccessToken:    accountData.Token,
-			IPv4:           updatedAccountData.Config.Interface.Addresses.V4,
-			IPv6:           updatedAccountData.Config.Interface.Addresses.V6,
+			EndpointPubKey: accountData.Config.Peers[0].PublicKey,
+			ID:             accountData.ID,
+			AccessToken:    config.AppConfig.AccessToken,
+			IPv4:           accountData.Config.Interface.Addresses.V4,
+			IPv6:           accountData.Config.Interface.Addresses.V6,
 		}
 
 		if err := config.AppConfig.SaveConfig(configPath); err != nil {

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -54,6 +54,7 @@ var enrollCmd = &cobra.Command{
 			publicKey    []byte
 		)
 
+	retry:
 		if regenKey {
 			log.Printf("Regenerating key pair...")
 			privKeyBytes, publicKey, err = internal.GenerateEcKeyPair()
@@ -77,9 +78,9 @@ var enrollCmd = &cobra.Command{
 			}
 		}
 
-		updatedAccountData, apiErr, err := api.EnrollKey(accountData, publicKey, deviceName)
+		updatedAccountData, err := api.EnrollKey(accountData, publicKey, deviceName)
 		if err != nil {
-			if apiErr != nil && apiErr.HasErrorMessage(models.InvalidPublicKey) {
+			if apiErr, ok := err.(models.APIError); ok && apiErr.HasErrorCode(models.InvalidPublicKey) {
 				fmt.Print("Invalid public key detected. Regenerate key? (y/n): ")
 
 				var response string
@@ -88,31 +89,12 @@ var enrollCmd = &cobra.Command{
 				}
 
 				if response == "y" {
-					log.Printf("Regenerating key pair...")
-					privKeyBytes, publicKey, err = internal.GenerateEcKeyPair()
-					if err != nil {
-						log.Fatalf("Failed to generate key pair: %v", err)
-					}
-
-					log.Println("Re-enrolling device key with new key pair...")
-					updatedAccountData, apiErr, err = api.EnrollKey(accountData, publicKey, deviceName)
-					if err != nil {
-						if apiErr != nil {
-							log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
-						}
-						log.Fatalf("Failed to enroll key: %v", err)
-					}
+					regenKey = true
+					goto retry
 				} else {
-					if apiErr != nil {
-						log.Fatalf("Enrollment aborted by user. API errors: %s", apiErr.ErrorsAsString("; "))
-					}
-					log.Fatal("Enrollment aborted by user.")
+					log.Fatalf("Enrollment aborted by user. %v", apiErr)
 				}
 			} else {
-				// apiErr is nil on transport errors etc. (#86).
-				if apiErr != nil {
-					log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
-				}
 				log.Fatalf("Failed to enroll key: %v", err)
 			}
 		}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -79,7 +79,7 @@ var registerCmd = &cobra.Command{
 
 		log.Printf("Enrolling device key...")
 
-		updatedAccountData, err := api.EnrollKey(accountData, pubKey, deviceName)
+		updatedAccountData, err := api.EnrollKey(accountData.ID, accountData.Token, pubKey, deviceName)
 		if err != nil {
 			log.Fatalf("Failed to enroll key: %v", err)
 		}
@@ -96,7 +96,6 @@ var registerCmd = &cobra.Command{
 			EndpointH2V4:   config.DefaultEndpointH2V4,
 			EndpointH2V6:   config.DefaultEndpointH2V6,
 			EndpointPubKey: updatedAccountData.Config.Peers[0].PublicKey,
-			License:        updatedAccountData.Account.License,
 			ID:             updatedAccountData.ID,
 			AccessToken:    accountData.Token,
 			IPv4:           updatedAccountData.Config.Interface.Addresses.V4,

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -79,13 +79,9 @@ var registerCmd = &cobra.Command{
 
 		log.Printf("Enrolling device key...")
 
-		updatedAccountData, apiErr, err := api.EnrollKey(accountData, pubKey, deviceName)
+		updatedAccountData, err := api.EnrollKey(accountData, pubKey, deviceName)
 		if err != nil {
-			if apiErr != nil {
-				log.Fatalf("Failed to enroll key: %v (API errors: %s)", err, apiErr.ErrorsAsString("; "))
-			} else {
-				log.Fatalf("Failed to enroll key: %v", err)
-			}
+			log.Fatalf("Failed to enroll key: %v", err)
 		}
 
 		log.Printf("Successful registration. Saving config...")

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	EndpointH2V4   string `json:"endpoint_h2_v4"`   // IPv4 address used in HTTP/2 mode
 	EndpointH2V6   string `json:"endpoint_h2_v6"`   // IPv6 address used in HTTP/2 mode
 	EndpointPubKey string `json:"endpoint_pub_key"` // PEM-encoded ECDSA public key of the endpoint to verify against
-	License        string `json:"license"`          // Application license key
 	ID             string `json:"id"`               // Device unique identifier
 	AccessToken    string `json:"access_token"`     // Authentication token for API access
 	IPv4           string `json:"ipv4"`             // Assigned IPv4 address

--- a/models/apierror.go
+++ b/models/apierror.go
@@ -1,17 +1,13 @@
 package models
 
-// Known error messages from the API
+// Known error codes from the API
 const (
-	InvalidPublicKey = "Invalid public key"
+	InvalidPublicKey = 1001
 )
 
 type APIError struct {
-	// not sure what type this is, so we will settle for interface{}
-	// for now
-	Result   interface{} `json:"result"`
-	Success  bool        `json:"success"`
-	Errors   []ErrorInfo `json:"errors"`
-	Messages []string    `json:"messages"`
+	Success bool        `json:"success"`
+	Errors  []ErrorInfo `json:"errors"`
 }
 
 type ErrorInfo struct {
@@ -38,19 +34,27 @@ func (e *APIError) ErrorsAsString(separator string) string {
 	return result
 }
 
-// HasErrorMessage checks if the APIError contains a specific error message.
-// It returns true if the error message is found, otherwise false.
+// HasErrorCode checks if the APIError contains a specific error code.
+// It returns true if the error code is found, otherwise false.
 //
 // Parameters:
-//   - message: string - The error message to check for.
+//   - code: int - The error code to check for.
 //
 // Returns:
-//   - bool: true if the error message is found, otherwise false.
-func (e *APIError) HasErrorMessage(message string) bool {
+//   - bool: true if the error code is found, otherwise false.
+func (e *APIError) HasErrorCode(code int) bool {
 	for _, err := range e.Errors {
-		if err.Message == message {
+		if err.Code == code {
 			return true
 		}
 	}
 	return false
+}
+
+// Error returns a string representation of api errors.
+//
+// Returns:
+//   - string: A string containing all error messages, separated by '; '.
+func (e APIError) Error() string {
+	return "API errors: " + e.ErrorsAsString("; ")
 }

--- a/models/register.go
+++ b/models/register.go
@@ -47,7 +47,7 @@ type AccountData struct {
 
 type Account struct {
 	ID          string `json:"id"`
-	AccountType string `json:"account_type"`
+	AccountType string `json:"account_type,omitempty"`
 	// Created not set for ZeroTier
 	Created string `json:"created,omitempty"`
 	// Updated not set for ZeroTier
@@ -99,4 +99,17 @@ type Peer struct {
 type Policy struct {
 	TunnelProtocol string `json:"tunnel_protocol"`
 	// TODO: add ZeroTier fields
+}
+
+type Devices []Device
+
+type Device struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Model     string `json:"model"`
+	Name      string `json:"name,omitempty"`
+	Created   string `json:"created"`
+	Activated string `json:"activated"`
+	Active    bool   `json:"active"`
+	Role      string `json:"role"`
 }


### PR DESCRIPTION
https://github.com/Diniboy1123/usque/issues/87

Added commands:

- account set - Associates a device with a WARP license key.
- account reset - Resets the license key (installs a new random one).
- account info - Displays information about the current configuration, including the current license key.
- account devices - Displays information about all devices using the same license key.