### PR TITLE
Add loose SOCKS UDP associate mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,16 @@ Test the proxy with `curl`:
 curl -x socks5://myuser:mypass@localhost:8080 https://cloudflare.com/cdn-cgi/trace
 ```
 
+Some SOCKS5 clients request UDP ASSOCIATE with an unspecified source address
+(`0.0.0.0:0` or `[::]:0`) and then send UDP from a different source port. If
+UDP works with other clients but those clients trigger `udp address ... is not
+associated with tcp`, start the proxy with `--loose-udp-associate` to bind the
+association to the first UDP packet from the same client IP:
+
+```shell
+$ ./usque socks --loose-udp-associate
+```
+
 > [!NOTE]
 > Since the proxy emulates its own networking stack, it's generally safe to say that users won't be able to access internal IPs and services the host has access to using the proxy. However the internal WARP network is available for them unfiltered. If you have ZeroTrust and Gateway on, users of your proxy may be able to reach each other as no manual filtering is applied. **Inside the tunnel they will be able to connect to any TCP or UDP service**.
 

--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -217,6 +217,12 @@ var socksCmd = &cobra.Command{
 			log.Println("Warning: --udp-timeout is 0; idle UDP ASSOCIATE exchanges will never expire. Memory will grow under heavy UDP traffic (DHT, uTP, etc.).")
 		}
 
+		looseUDPAssociate, err := cmd.Flags().GetBool("loose-udp-associate")
+		if err != nil {
+			cmd.Printf("Failed to get loose UDP ASSOCIATE flag: %v\n", err)
+			return
+		}
+
 		alwaysReconnect, err := cmd.Flags().GetBool("always-reconnect")
 		if err != nil {
 			cmd.Printf("Failed to get always-reconnect flag: %v\n", err)
@@ -273,13 +279,14 @@ var socksCmd = &cobra.Command{
 		}
 
 		server, err := internal.NewSOCKS5Server(internal.SOCKS5Config{
-			Addr:       net.JoinHostPort(bindAddress, port),
-			Username:   username,
-			Password:   password,
-			Resolver:   resolver,
-			TunNet:     tunNet,
-			UDPTimeout: udpTimeout,
-			Logger:     log.New(internal.NewTZStampWriter(os.Stderr), "socks5: ", 0),
+			Addr:              net.JoinHostPort(bindAddress, port),
+			Username:          username,
+			Password:          password,
+			Resolver:          resolver,
+			TunNet:            tunNet,
+			UDPTimeout:        udpTimeout,
+			LooseUDPAssociate: looseUDPAssociate,
+			Logger:            log.New(internal.NewTZStampWriter(os.Stderr), "socks5: ", 0),
 		})
 		if err != nil {
 			cmd.Printf("Failed to create SOCKS proxy: %v\n", err)
@@ -311,6 +318,7 @@ func init() {
 	socksCmd.Flags().Uint16P("initial-packet-size", "i", 0, "Custom initial packet size for MASQUE connection (default: auto with PMTU discovery)")
 	socksCmd.Flags().DurationP("reconnect-delay", "r", 1*time.Second, "Delay between reconnect attempts")
 	socksCmd.Flags().Duration("udp-timeout", 60*time.Second, "Idle read deadline for each remote UDP relay (SOCKS5 ASSOCIATE). Shorter frees memory sooner; raise (e.g. 300s) if a quiet peer needs longer silence. 0 disables the deadline and risks unbounded growth under DHT/uTP")
+	socksCmd.Flags().Bool("loose-udp-associate", false, "Accept the first UDP source port from clients that request UDP ASSOCIATE with 0.0.0.0:0 or [::]:0")
 	socksCmd.Flags().Bool("always-reconnect", false, "Always reconnect after tunnel loss, even when idle")
 	socksCmd.Flags().Bool("http2", false, "Use HTTP/2 over TCP+TLS instead of HTTP/3 over QUIC."+config.EndpointHelpSuffixH2)
 	socksCmd.Flags().Bool("insecure", false, "Disable endpoint certificate pinning and trust any certificate")

--- a/internal/socks5.go
+++ b/internal/socks5.go
@@ -18,22 +18,43 @@ import (
 
 // SOCKS5Config holds listen address, auth, tunnel dialers, and timeouts for [SOCKS5Server].
 type SOCKS5Config struct {
-	Addr       string
-	Username   string
-	Password   string
-	Resolver   *TunnelDNSResolver
-	TunNet     *netstack.Net
-	DialTCP    func(ctx context.Context, network, address string) (net.Conn, error)
-	TCPOnly    bool
-	TCPTimeout time.Duration // 0 = no deadline on TCP CONNECT relay
-	UDPTimeout time.Duration // 0 = no deadline on remote UDP reads
-	Logger     *log.Logger
+	Addr              string
+	Username          string
+	Password          string
+	Resolver          *TunnelDNSResolver
+	TunNet            *netstack.Net
+	DialTCP           func(ctx context.Context, network, address string) (net.Conn, error)
+	TCPOnly           bool
+	LooseUDPAssociate bool
+	TCPTimeout        time.Duration // 0 = no deadline on TCP CONNECT relay
+	UDPTimeout        time.Duration // 0 = no deadline on remote UDP reads
+	Logger            *log.Logger
 }
 
 // SOCKS5Server wraps txthinking/socks5; DialTCP/DialUDP are package globals (last NewSOCKS5Server wins).
 type SOCKS5Server struct {
-	cfg    SOCKS5Config
-	server *socks5.Server
+	cfg                 SOCKS5Config
+	server              *socks5.Server
+	udpAssociationMutex sync.Mutex
+	pendingUDP          map[string][]*udpAssociation
+}
+
+type udpAssociation struct {
+	mu     sync.Mutex
+	ch     chan byte
+	source string
+}
+
+func (a *udpAssociation) setSource(source string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.source = source
+}
+
+func (a *udpAssociation) getSource() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.source
 }
 
 func NewSOCKS5Server(cfg SOCKS5Config) (*SOCKS5Server, error) {
@@ -62,7 +83,11 @@ func NewSOCKS5Server(cfg SOCKS5Config) (*SOCKS5Server, error) {
 		return nil, err
 	}
 
-	s := &SOCKS5Server{cfg: cfg, server: srv}
+	s := &SOCKS5Server{
+		cfg:        cfg,
+		server:     srv,
+		pendingUDP: make(map[string][]*udpAssociation),
+	}
 	if cfg.TCPOnly {
 		srv.SupportedCommands = []byte{socks5.CmdConnect}
 	}
@@ -312,10 +337,22 @@ func (s *SOCKS5Server) TCPHandle(srv *socks5.Server, c *net.TCPConn, r *socks5.R
 		if err != nil {
 			return err
 		}
-		ch := make(chan byte)
-		defer close(ch)
-		srv.AssociatedUDP.Set(caddr.String(), ch, -1)
-		defer srv.AssociatedUDP.Delete(caddr.String())
+		assoc := &udpAssociation{ch: make(chan byte)}
+		defer close(assoc.ch)
+		if s.cfg.LooseUDPAssociate && isZeroUDPAssociateRequest(r) {
+			sourceIP := socksClientIP(c.RemoteAddr())
+			s.addPendingUDPAssociation(sourceIP, assoc)
+			defer func() {
+				s.removePendingUDPAssociation(sourceIP, assoc)
+				if source := assoc.getSource(); source != "" {
+					srv.AssociatedUDP.Delete(source)
+				}
+			}()
+		} else {
+			assoc.setSource(caddr.String())
+			srv.AssociatedUDP.Set(assoc.getSource(), assoc, -1)
+			defer srv.AssociatedUDP.Delete(assoc.getSource())
+		}
 		_, _ = io.Copy(io.Discard, c)
 		return nil
 	}
@@ -363,17 +400,32 @@ func (s *SOCKS5Server) relayTCP(a, b net.Conn, timeout time.Duration) {
 // UDPHandle is like txthinking DefaultHandle.UDPHandle but does not use srv.UDPSrc.
 func (s *SOCKS5Server) UDPHandle(srv *socks5.Server, addr *net.UDPAddr, d *socks5.Datagram) error {
 	src := addr.String()
-	var ch chan byte
+	var assoc *udpAssociation
+	var associatedClosed <-chan byte
 	if srv.LimitUDP {
 		any, ok := srv.AssociatedUDP.Get(src)
 		if !ok {
-			return fmt.Errorf("udp address %s is not associated with tcp", src)
+			if s.cfg.LooseUDPAssociate {
+				assoc, ok = s.claimPendingUDPAssociation(addr)
+				if ok {
+					assoc.setSource(src)
+					srv.AssociatedUDP.Set(src, assoc, -1)
+				}
+			}
+			if !ok {
+				return fmt.Errorf("udp address %s is not associated with tcp", src)
+			}
+		} else {
+			assoc, ok = any.(*udpAssociation)
+			if !ok {
+				return fmt.Errorf("udp address %s has invalid association state", src)
+			}
 		}
-		ch = any.(chan byte)
+		associatedClosed = assoc.ch
 	}
 	send := func(ue *socks5.UDPExchange, data []byte) error {
 		select {
-		case <-ch:
+		case <-associatedClosed:
 			return fmt.Errorf("udp address %s is not associated with tcp", src)
 		default:
 			_, err := ue.RemoteConn.Write(data)
@@ -421,7 +473,7 @@ func (s *SOCKS5Server) UDPHandle(srv *socks5.Server, addr *net.UDPAddr, d *socks
 		defer udpReadBufPool.Put(rbp)
 		for {
 			select {
-			case <-ch:
+			case <-associatedClosed:
 				return
 			default:
 				// Use full time.Duration (NewClassicServer only gets whole seconds).
@@ -464,4 +516,78 @@ func (s *SOCKS5Server) UDPHandle(srv *socks5.Server, addr *net.UDPAddr, d *socks
 	}(ue, dst)
 
 	return nil
+}
+
+func isZeroUDPAssociateRequest(r *socks5.Request) bool {
+	if len(r.DstPort) != 2 || r.DstPort[0] != 0 || r.DstPort[1] != 0 {
+		return false
+	}
+	switch r.Atyp {
+	case socks5.ATYPIPv4, socks5.ATYPIPv6:
+		return net.IP(r.DstAddr).IsUnspecified()
+	default:
+		return false
+	}
+}
+
+func socksClientIP(addr net.Addr) string {
+	switch typedAddr := addr.(type) {
+	case *net.TCPAddr:
+		return typedAddr.IP.String()
+	case *net.UDPAddr:
+		return typedAddr.IP.String()
+	default:
+		host, _, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			return addr.String()
+		}
+		return host
+	}
+}
+
+func (s *SOCKS5Server) addPendingUDPAssociation(sourceIP string, assoc *udpAssociation) {
+	s.udpAssociationMutex.Lock()
+	defer s.udpAssociationMutex.Unlock()
+	s.pendingUDP[sourceIP] = append(s.pendingUDP[sourceIP], assoc)
+}
+
+func (s *SOCKS5Server) removePendingUDPAssociation(sourceIP string, assoc *udpAssociation) {
+	s.udpAssociationMutex.Lock()
+	defer s.udpAssociationMutex.Unlock()
+	pending := s.pendingUDP[sourceIP]
+	for index, current := range pending {
+		if current == assoc {
+			pending = append(pending[:index], pending[index+1:]...)
+			break
+		}
+	}
+	if len(pending) == 0 {
+		delete(s.pendingUDP, sourceIP)
+		return
+	}
+	s.pendingUDP[sourceIP] = pending
+}
+
+func (s *SOCKS5Server) claimPendingUDPAssociation(addr *net.UDPAddr) (*udpAssociation, bool) {
+	sourceIP := addr.IP.String()
+	s.udpAssociationMutex.Lock()
+	defer s.udpAssociationMutex.Unlock()
+	pending := s.pendingUDP[sourceIP]
+	for len(pending) > 0 {
+		assoc := pending[0]
+		pending = pending[1:]
+		select {
+		case <-assoc.ch:
+			continue
+		default:
+			if len(pending) == 0 {
+				delete(s.pendingUDP, sourceIP)
+			} else {
+				s.pendingUDP[sourceIP] = pending
+			}
+			return assoc, true
+		}
+	}
+	delete(s.pendingUDP, sourceIP)
+	return nil, false
 }

--- a/internal/socks5_test.go
+++ b/internal/socks5_test.go
@@ -1,0 +1,177 @@
+package internal
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/txthinking/runnergroup"
+	"github.com/txthinking/socks5"
+)
+
+func TestIsZeroUDPAssociateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *socks5.Request
+		want bool
+	}{
+		{
+			name: "ipv4 zero",
+			req: &socks5.Request{
+				Atyp:    socks5.ATYPIPv4,
+				DstAddr: []byte{0, 0, 0, 0},
+				DstPort: []byte{0, 0},
+			},
+			want: true,
+		},
+		{
+			name: "ipv6 zero",
+			req: &socks5.Request{
+				Atyp:    socks5.ATYPIPv6,
+				DstAddr: net.IPv6zero,
+				DstPort: []byte{0, 0},
+			},
+			want: true,
+		},
+		{
+			name: "explicit source port",
+			req: &socks5.Request{
+				Atyp:    socks5.ATYPIPv4,
+				DstAddr: []byte{0, 0, 0, 0},
+				DstPort: []byte{0x12, 0x34},
+			},
+			want: false,
+		},
+		{
+			name: "explicit source address",
+			req: &socks5.Request{
+				Atyp:    socks5.ATYPIPv4,
+				DstAddr: []byte{192, 0, 2, 10},
+				DstPort: []byte{0, 0},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isZeroUDPAssociateRequest(test.req); got != test.want {
+				t.Fatalf("isZeroUDPAssociateRequest() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUDPHandleRejectsUnassociatedUDPInStrictMode(t *testing.T) {
+	server := newTestSocksServer()
+	handler := &SOCKS5Server{
+		cfg:        SOCKS5Config{},
+		server:     server,
+		pendingUDP: make(map[string][]*udpAssociation),
+	}
+
+	err := handler.UDPHandle(server, udpAddr("192.0.2.10", 40000), testDatagram())
+	if err == nil {
+		t.Fatal("expected unassociated UDP packet to fail")
+	}
+}
+
+func TestUDPHandleClaimsPendingZeroAssociateInLooseMode(t *testing.T) {
+	server := newTestSocksServer()
+	assoc := &udpAssociation{ch: make(chan byte)}
+	handler := &SOCKS5Server{
+		cfg: SOCKS5Config{
+			LooseUDPAssociate: true,
+		},
+		server: server,
+		pendingUDP: map[string][]*udpAssociation{
+			"192.0.2.10": {assoc},
+		},
+	}
+
+	conn := &recordingPacketConn{}
+	oldDialUDP := socks5.DialUDP
+	socks5.DialUDP = func(_, _, _ string) (net.Conn, error) {
+		return conn, nil
+	}
+	t.Cleanup(func() { socks5.DialUDP = oldDialUDP })
+
+	err := handler.UDPHandle(server, udpAddr("192.0.2.10", 40000), testDatagram())
+	if err != nil {
+		t.Fatalf("UDPHandle() error = %v", err)
+	}
+	if source := assoc.getSource(); source != "192.0.2.10:40000" {
+		t.Fatalf("assoc.source = %q, want %q", source, "192.0.2.10:40000")
+	}
+	if _, ok := server.AssociatedUDP.Get("192.0.2.10:40000"); !ok {
+		t.Fatal("claimed UDP association was not registered")
+	}
+	if _, ok := handler.pendingUDP["192.0.2.10"]; ok {
+		t.Fatal("pending UDP association was not removed")
+	}
+	if !bytes.Equal(conn.written.Bytes(), []byte("payload")) {
+		t.Fatalf("remote UDP payload = %q, want %q", conn.written.String(), "payload")
+	}
+}
+
+func newTestSocksServer() *socks5.Server {
+	return &socks5.Server{
+		AssociatedUDP: cache.New(cache.NoExpiration, cache.NoExpiration),
+		UDPExchanges:  cache.New(cache.NoExpiration, cache.NoExpiration),
+		LimitUDP:      true,
+		RunnerGroup:   runnergroup.New(),
+	}
+}
+
+func udpAddr(ip string, port int) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(ip), Port: port}
+}
+
+func testDatagram() *socks5.Datagram {
+	return &socks5.Datagram{
+		Rsv:     []byte{0, 0},
+		Frag:    0,
+		Atyp:    socks5.ATYPIPv4,
+		DstAddr: []byte{1, 1, 1, 1},
+		DstPort: []byte{0, 53},
+		Data:    []byte("payload"),
+	}
+}
+
+type recordingPacketConn struct {
+	written bytes.Buffer
+}
+
+func (c *recordingPacketConn) Read(_ []byte) (int, error) {
+	select {}
+}
+
+func (c *recordingPacketConn) Write(p []byte) (int, error) {
+	return c.written.Write(p)
+}
+
+func (c *recordingPacketConn) Close() error {
+	return nil
+}
+
+func (c *recordingPacketConn) LocalAddr() net.Addr {
+	return udpAddr("100.64.0.2", 12345)
+}
+
+func (c *recordingPacketConn) RemoteAddr() net.Addr {
+	return udpAddr("1.1.1.1", 53)
+}
+
+func (c *recordingPacketConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *recordingPacketConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *recordingPacketConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}


### PR DESCRIPTION
This adds an opt-in `--loose-udp-associate` flag for SOCKS5 proxy mode.

Some SOCKS5 clients send UDP ASSOCIATE with an unspecified source address (`0.0.0.0:0` / `[::]:0`) and then send UDP packets from a different local source port. With the existing strict UDP association check, those packets are rejected as not associated with the TCP control connection.

When this flag is enabled, usque keeps strict behavior for explicit UDP ASSOCIATE source addresses, but for unspecified source requests it binds the association to the first UDP packet from the same client IP.

This helps compatibility with clients such as sing-box while keeping the default behavior unchanged.

Tests:
- go test ./...
- go test -race ./internal