### PR TITLE
[codex] fix: honor Config receiver and certificate public key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,7 @@ func LoadConfig(configPath string) error {
 //
 // Returns:
 //   - error: An error if the configuration file cannot be written.
-func (*Config) SaveConfig(configPath string) error {
+func (c *Config) SaveConfig(configPath string) error {
 	file, err := os.Create(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to create config file: %v", err)
@@ -70,7 +70,7 @@ func (*Config) SaveConfig(configPath string) error {
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(AppConfig); err != nil {
+	if err := encoder.Encode(c); err != nil {
 		return fmt.Errorf("failed to encode config file: %v", err)
 	}
 
@@ -82,8 +82,8 @@ func (*Config) SaveConfig(configPath string) error {
 // Returns:
 //   - *ecdsa.PrivateKey: The parsed ECDSA private key.
 //   - error: An error if decoding or parsing the private key fails.
-func (*Config) GetEcPrivateKey() (*ecdsa.PrivateKey, error) {
-	privKeyB64, err := base64.StdEncoding.DecodeString(AppConfig.PrivateKey)
+func (c *Config) GetEcPrivateKey() (*ecdsa.PrivateKey, error) {
+	privKeyB64, err := base64.StdEncoding.DecodeString(c.PrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode private key: %v", err)
 	}
@@ -101,8 +101,8 @@ func (*Config) GetEcPrivateKey() (*ecdsa.PrivateKey, error) {
 // Returns:
 //   - *ecdsa.PublicKey: The parsed ECDSA public key.
 //   - error: An error if decoding or parsing the public key fails.
-func (*Config) GetEcEndpointPublicKey() (*ecdsa.PublicKey, error) {
-	endpointPubKeyB64, _ := pem.Decode([]byte(AppConfig.EndpointPubKey))
+func (c *Config) GetEcEndpointPublicKey() (*ecdsa.PublicKey, error) {
+	endpointPubKeyB64, _ := pem.Decode([]byte(c.EndpointPubKey))
 	if endpointPubKeyB64 == nil {
 		return nil, fmt.Errorf("failed to decode endpoint public key")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestPrivateKey(t *testing.T) (string, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(der), key
+}
+
+func TestConfigMethodsUseReceiver(t *testing.T) {
+	receiverKey, receiverPrivate := newTestPrivateKey(t)
+	globalKey, _ := newTestPrivateKey(t)
+	previous := AppConfig
+	defer func() { AppConfig = previous }()
+	AppConfig = Config{PrivateKey: globalKey, ID: "global"}
+
+	receiver := Config{PrivateKey: receiverKey, ID: "receiver"}
+	gotKey, err := receiver.GetEcPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gotKey.PublicKey.Equal(&receiverPrivate.PublicKey) {
+		t.Fatal("GetEcPrivateKey did not use the receiver")
+	}
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := receiver.SaveConfig(path); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved Config
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.ID != receiver.ID {
+		t.Fatalf("SaveConfig wrote ID %q; want %q", saved.ID, receiver.ID)
+	}
+}
+
+func TestGetEcEndpointPublicKeyUsesReceiver(t *testing.T) {
+	_, receiverPrivate := newTestPrivateKey(t)
+	_, globalPrivate := newTestPrivateKey(t)
+	receiverDER, err := x509.MarshalPKIXPublicKey(&receiverPrivate.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalDER, err := x509.MarshalPKIXPublicKey(&globalPrivate.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := AppConfig
+	defer func() { AppConfig = previous }()
+	AppConfig = Config{EndpointPubKey: string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: globalDER}))}
+
+	receiver := Config{EndpointPubKey: string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: receiverDER}))}
+	gotKey, err := receiver.GetEcEndpointPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gotKey.Equal(&receiverPrivate.PublicKey) {
+		t.Fatal("GetEcEndpointPublicKey did not use the receiver")
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -104,11 +104,18 @@ func GenerateEcKeyPair() ([]byte, []byte, error) {
 //   - [][]byte: A slice containing the certificate in DER format.
 //   - error:    An error if certificate generation fails.
 func GenerateCert(privKey *ecdsa.PrivateKey, pubKey *ecdsa.PublicKey) ([][]byte, error) {
+	if privKey == nil {
+		return nil, errors.New("private key is required")
+	}
+	if pubKey == nil {
+		return nil, errors.New("public key is required")
+	}
+
 	cert, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
 		SerialNumber: big.NewInt(0),
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(1 * 24 * time.Hour),
-	}, &x509.Certificate{}, &privKey.PublicKey, privKey)
+	}, &x509.Certificate{}, pubKey, privKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"testing"
+)
+
+func TestGenerateCertUsesProvidedPublicKey(t *testing.T) {
+	signingKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	der, err := GenerateCert(signingKey, &expectedKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("certificate public key has type %T", cert.PublicKey)
+	}
+	if !publicKey.Equal(&expectedKey.PublicKey) {
+		t.Fatal("certificate did not use the provided public key")
+	}
+}


### PR DESCRIPTION
## Why

`Config` methods have pointer receivers, but `SaveConfig`, `GetEcPrivateKey`, and `GetEcEndpointPublicKey` were reading or writing the process-wide `AppConfig` instead of the receiver. That is surprising for callers using the package as a library and can read from or write to the wrong configuration.

`GenerateCert` also accepted a public-key argument but always embedded the public key from the signing private key, silently ignoring its argument.

## What changed

- Make the `Config` methods operate on their receiver.
- Make `GenerateCert` embed the supplied public key and reject nil key arguments.
- Add regression tests for the receiver behavior and certificate public key.

## Validation

- `go test ./...`
- `go build -ldflags="-s -w" -o usque.exe .`
- Rebuilt the Windows amd64 binary locally with Go 1.26.3 and ran `usque.exe --help` successfully.
