### PR TITLE
Add native TUN (utun) support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Usque is an open-source reimplementation of the Cloudflare WARP client's MASQUE 
   - [Usage](#usage)
     - [Registration](#registration)
     - [Enrolling](#enrolling)
-    - [Native Tunnel Mode (for Advanced Users, Linux and Windows only!)](#native-tunnel-mode-for-advanced-users-linux-and-windows-only)
+    - [Native Tunnel Mode (for Advanced Users, Linux, Windows and macOS only!)](#native-tunnel-mode-for-advanced-users-linux-windows-and-macos-only)
       - [On Linux](#on-linux)
       - [On Windows](#on-windows)
+      - [On macOS](#on-macos)
       - [Routes on Linux](#routes-on-linux)
       - [Routes on Windows](#routes-on-windows)
+      - [Routes on macOS](#routes-on-macos)
     - [SOCKS5 Proxy Mode (easy, cross-platform)](#socks5-proxy-mode-easy-cross-platform)
     - [HTTP Proxy Mode (easy, cross-platform)](#http-proxy-mode-easy-cross-platform)
     - [L4 Proxy Modes (easy, cross-platform)](#l4-proxy-modes-easy-cross-platform)
@@ -152,7 +154,7 @@ While the registration command also handles device enrollment, in some cases, yo
 $ ./usque enroll
 ```
 
-### Native Tunnel Mode (for Advanced Users, Linux and Windows only!)
+### Native Tunnel Mode (for Advanced Users, Linux, Windows and macOS only!)
 
 The native tunnel is a good choice when you want a real network interface. It is also one of the faster modes of operation.
 
@@ -164,13 +166,17 @@ It **requires the `TUN` device** to be available on the system. This means your 
 
 It requires the [wintun.dll](https://www.wintun.net/) file to be present in the same directory as the `usque.exe` binary. Then it will take care of bringing up the interface and setting the IP addresses. Normally this also requires administrative privileges.
 
+#### On macOS
+
+It uses the built-in `utun` device (via [wireguard-go/tun](https://git.zx2c4.com/wireguard-go/about/)), so no extra kernel modules or DLLs are needed. `usque` creates the interface, assigns the WARP IPv4/IPv6 addresses and MTU with `ifconfig(8)`, and brings it up. macOS `utun` devices carry a 4-byte address-family header, which is handled internally, so the tunnel still transports raw IPv4/IPv6 — including **UDP** (QUIC/HTTP-3, WebRTC, DNS), unlike the SOCKS5 proxy mode. Creating the interface **requires root privileges** (`sudo`). In testing on Apple Silicon, throughput was competitive with the official WARP client (hundreds of Mbit/s to Cloudflare-fronted endpoints; tens of Mbit/s to distant non-Cloudflare hosts).
+
 To bring up a native tunnel, execute:
 
 ```shell
 $ sudo ./usque nativetun
 ```
 
-Unless otherwise specified, you should see a `tun0` (or `tun1`, `tun2`, etc.) interface appear on Linux. On Windows, the interface is typically named `usque`. If you didn't disable IPv4 and IPv6 inside the tunnel using cli flags (on Linux), you should also see the IPv4 and IPv6 address pre-assigned to this interface. This should be enough for applications that can route traffic through a specific network interface to function. For example `ping`:
+Unless otherwise specified, you should see a `tun0` (or `tun1`, `tun2`, etc.) interface appear on Linux. On Windows, the interface is typically named `usque`. On macOS, it is a kernel-assigned `utunN` device (for example `utun6`; pass `-n`/`--interface-name` to request a specific unit). If you didn't disable IPv4 and IPv6 inside the tunnel using cli flags (on Linux), you should also see the IPv4 and IPv6 address pre-assigned to this interface. This should be enough for applications that can route traffic through a specific network interface to function. For example `ping`:
 
 ```shell
 $ ping -I tun0 1.1
@@ -244,6 +250,23 @@ route add ::/0 [TUNNEL_GATEWAY] metric 1 if [TUN_INTERFACE_INDEX]
 
 > [!NOTE]
 > Replace `[TUNNEL_GATEWAY]` and `[TUN_INTERFACE_INDEX]` with the actual values for your tunnel adapter. You can get these by checking `ipconfig` and `route print`.
+
+#### Routes on macOS
+
+Assuming your regular interface is `en0`, your gateway is `192.168.1.1`, and the tunnel came up as `utun6`, first pin the tunnel endpoint to your physical gateway so usque's own MASQUE/QUIC connection does not loop back into the tunnel:
+
+```shell
+$ sudo route -n add -host 162.159.198.1 192.168.1.1
+```
+
+Then redirect the default route through the tunnel. Using the split-default `0.0.0.0/1` + `128.0.0.0/1` pair (instead of replacing `default`) leaves your original default route intact, which makes rollback easier:
+
+```shell
+$ sudo route -n add -net 0.0.0.0/1 -interface utun6
+$ sudo route -n add -net 128.0.0.0/1 -interface utun6
+```
+
+To undo, delete those routes (`sudo route -n delete -net 0.0.0.0/1 -interface utun6`, etc.) or simply stop `usque`, which tears the interface down.
 
 > [!CAUTION]
 > Always be careful with default routes, especially if you are running this on a headless machine. It is very easy to close yourself out of your current session. I suggest [network namespaces](https://man7.org/linux/man-pages/man7/network_namespaces.7.html) on Linux as a safer playground for experiments or a spare VM with physical access or serial console.

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -66,11 +66,18 @@ type TunnelDevice interface {
 	WritePacket(pkt []byte) error
 }
 
-// NetstackAdapter wraps a tun.Device (e.g. from netstack) to satisfy TunnelDevice.
+// NetstackAdapter wraps a tun.Device (for example wireguard-go/tun) to satisfy
+// TunnelDevice. Some platforms — notably the BSDs (FreeBSD, macOS) — require a
+// small packet headroom when using tun.Device.Read/Write because the
+// kernel-facing device carries a 4-byte address-family header. The offset field
+// lets platform-specific callers request that headroom while keeping the tunnel
+// pump raw-IP-only.
 type NetstackAdapter struct {
 	dev             tun.Device
+	offset          int
 	tunnelBufPool   sync.Pool
 	tunnelSizesPool sync.Pool
+	packetBufPool   sync.Pool
 }
 
 func (n *NetstackAdapter) ReadPacket(buf []byte) (int, error) {
@@ -83,15 +90,38 @@ func (n *NetstackAdapter) ReadPacket(buf []byte) (int, error) {
 		n.tunnelSizesPool.Put(sizesPtr)
 	}()
 
-	(*packetBufsPtr)[0] = buf
+	readBuf := buf
+	var pooledBufPtr *[]byte
+	if n.offset > 0 {
+		pooledBufPtr = n.packetBufPool.Get().(*[]byte)
+		pooledBuf := *pooledBufPtr
+		needed := len(buf) + n.offset
+		if cap(pooledBuf) < needed {
+			pooledBuf = make([]byte, needed)
+		}
+		readBuf = pooledBuf[:needed]
+	}
+
+	(*packetBufsPtr)[0] = readBuf
 	(*sizesPtr)[0] = 0
 
-	_, err := n.dev.Read(*packetBufsPtr, *sizesPtr, 0)
+	_, err := n.dev.Read(*packetBufsPtr, *sizesPtr, n.offset)
 	if err != nil {
+		if pooledBufPtr != nil {
+			*pooledBufPtr = readBuf[:0]
+			n.packetBufPool.Put(pooledBufPtr)
+		}
 		return 0, err
 	}
 
-	return (*sizesPtr)[0], nil
+	size := (*sizesPtr)[0]
+	if n.offset > 0 {
+		copy(buf, readBuf[n.offset:n.offset+size])
+		*pooledBufPtr = readBuf[:0]
+		n.packetBufPool.Put(pooledBufPtr)
+	}
+
+	return size, nil
 }
 
 func (n *NetstackAdapter) WritePacket(pkt []byte) error {
@@ -101,15 +131,47 @@ func (n *NetstackAdapter) WritePacket(pkt []byte) error {
 		n.tunnelBufPool.Put(packetBufsPtr)
 	}()
 
-	(*packetBufsPtr)[0] = pkt
-	_, err := n.dev.Write(*packetBufsPtr, 0)
+	writeBuf := pkt
+	var pooledBufPtr *[]byte
+	if n.offset > 0 {
+		pooledBufPtr = n.packetBufPool.Get().(*[]byte)
+		pooledBuf := *pooledBufPtr
+		needed := len(pkt) + n.offset
+		if cap(pooledBuf) < needed {
+			pooledBuf = make([]byte, needed)
+		}
+		writeBuf = pooledBuf[:needed]
+		copy(writeBuf[n.offset:], pkt)
+	}
+
+	(*packetBufsPtr)[0] = writeBuf
+	_, err := n.dev.Write(*packetBufsPtr, n.offset)
+
+	if pooledBufPtr != nil {
+		*pooledBufPtr = writeBuf[:0]
+		n.packetBufPool.Put(pooledBufPtr)
+	}
+
 	return err
 }
 
-// NewNetstackAdapter creates a new NetstackAdapter.
+// NewNetstackAdapter creates a new NetstackAdapter without packet headroom
+// (offset 0), suitable for Linux/Windows tun devices.
 func NewNetstackAdapter(dev tun.Device) TunnelDevice {
+	return NewNetstackAdapterWithOffset(dev, 0)
+}
+
+// NewNetstackAdapterWithOffset creates a NetstackAdapter with platform-specific
+// packet headroom for tun.Device.Read/Write. Use offset 4 on the BSDs (FreeBSD,
+// macOS), whose utun/tun devices carry a 4-byte address-family header.
+func NewNetstackAdapterWithOffset(dev tun.Device, offset int) TunnelDevice {
+	if offset < 0 {
+		panic("offset must not be negative")
+	}
+
 	return &NetstackAdapter{
-		dev: dev,
+		dev:    dev,
+		offset: offset,
 		tunnelBufPool: sync.Pool{
 			New: func() interface{} {
 				buf := make([][]byte, 1)
@@ -120,6 +182,12 @@ func NewNetstackAdapter(dev tun.Device) TunnelDevice {
 			New: func() interface{} {
 				sizes := make([]int, 1)
 				return &sizes
+			},
+		},
+		packetBufPool: sync.Pool{
+			New: func() interface{} {
+				buf := make([]byte, 0)
+				return &buf
 			},
 		},
 	}

--- a/api/tunnel_test.go
+++ b/api/tunnel_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+// fakeTun drives NetstackAdapter without a real device. Read hands back a queued
+// IP packet placed at the requested offset; Write records the bytes it received
+// at the offset. This mirrors the contract NetstackAdapter relies on from
+// wireguard-go/tun: the IP packet lives at bufs[0][offset:], sizes[0] is its length.
+type fakeTun struct {
+	readQueue       [][]byte
+	lastWrite       []byte
+	lastReadOffset  int
+	lastWriteOffset int
+}
+
+func (f *fakeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	f.lastReadOffset = offset
+	if len(f.readQueue) == 0 {
+		return 0, os.ErrClosed
+	}
+	pkt := f.readQueue[0]
+	f.readQueue = f.readQueue[1:]
+	sizes[0] = copy(bufs[0][offset:], pkt)
+	return 1, nil
+}
+
+func (f *fakeTun) Write(bufs [][]byte, offset int) (int, error) {
+	f.lastWriteOffset = offset
+	f.lastWrite = append([]byte(nil), bufs[0][offset:]...)
+	return len(bufs), nil
+}
+
+func (f *fakeTun) File() *os.File           { return nil }
+func (f *fakeTun) MTU() (int, error)        { return 1280, nil }
+func (f *fakeTun) Name() (string, error)    { return "faketun", nil }
+func (f *fakeTun) Events() <-chan tun.Event { return nil }
+func (f *fakeTun) Close() error             { return nil }
+func (f *fakeTun) BatchSize() int           { return 1 }
+
+func pattern(n int) []byte {
+	p := make([]byte, n)
+	for i := range p {
+		p[i] = byte(i%251 + 1)
+	}
+	return p
+}
+
+// TestNetstackAdapterRoundTrip verifies read and write move the raw IP packet
+// intact for both the offset-0 path (Linux/Windows/SOCKS) and the offset-4 path
+// (BSD/macOS), across empty, small, and full-MTU packets.
+func TestNetstackAdapterRoundTrip(t *testing.T) {
+	for _, offset := range []int{0, 4} {
+		for _, size := range []int{0, 1, 20, 1280} {
+			pkt := pattern(size)
+
+			dev := &fakeTun{readQueue: [][]byte{append([]byte(nil), pkt...)}}
+			a := NewNetstackAdapterWithOffset(dev, offset)
+
+			buf := make([]byte, 1500)
+			n, err := a.ReadPacket(buf)
+			if err != nil {
+				t.Fatalf("offset=%d size=%d: ReadPacket: %v", offset, size, err)
+			}
+			if dev.lastReadOffset != offset {
+				t.Fatalf("offset=%d: device Read got offset %d", offset, dev.lastReadOffset)
+			}
+			if n != size || !bytes.Equal(buf[:n], pkt) {
+				t.Fatalf("offset=%d size=%d: read back %d bytes, content mismatch", offset, size, n)
+			}
+
+			if err := a.WritePacket(pkt); err != nil {
+				t.Fatalf("offset=%d size=%d: WritePacket: %v", offset, size, err)
+			}
+			if dev.lastWriteOffset != offset {
+				t.Fatalf("offset=%d: device Write got offset %d", offset, dev.lastWriteOffset)
+			}
+			if !bytes.Equal(dev.lastWrite[:size], pkt) {
+				t.Fatalf("offset=%d size=%d: device received wrong bytes", offset, size)
+			}
+		}
+	}
+}
+
+// TestNetstackAdapterZeroOffsetPassthrough pins the invariant that matters most
+// for existing platforms: with offset 0, the caller's buffer is handed straight
+// to the device (no headroom copy), so behaviour is unchanged by the offset
+// generalization.
+func TestNetstackAdapterZeroOffsetPassthrough(t *testing.T) {
+	pkt := pattern(64)
+	dev := &fakeTun{readQueue: [][]byte{append([]byte(nil), pkt...)}}
+	a := NewNetstackAdapter(dev)
+
+	buf := make([]byte, 1500)
+	n, err := a.ReadPacket(buf)
+	if err != nil || n != 64 || !bytes.Equal(buf[:n], pkt) {
+		t.Fatalf("zero-offset read mismatch: n=%d err=%v", n, err)
+	}
+	if dev.lastReadOffset != 0 {
+		t.Fatalf("zero-offset used device offset %d, want 0", dev.lastReadOffset)
+	}
+}

--- a/cmd/nativetun_darwin.go
+++ b/cmd/nativetun_darwin.go
@@ -1,0 +1,59 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Diniboy1123/usque/api"
+	"github.com/Diniboy1123/usque/config"
+	"github.com/Diniboy1123/usque/internal"
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+var longDescription = "Expose Warp as a native TUN device that accepts any IP traffic." +
+	" Requires root."
+
+// macOS utun devices prepend a 4-byte address-family header; wireguard-go/tun
+// exposes it as a read/write offset that the shared NetstackAdapter strips.
+const darwinTunOffset = 4
+
+func (t *tunDevice) create() (api.TunnelDevice, error) {
+	if t.name == "" {
+		t.name = "utun"
+	}
+
+	dev, err := tun.CreateTUN(t.name, t.mtu)
+	if err != nil {
+		return nil, err
+	}
+
+	t.name, err = dev.Name()
+	if err != nil {
+		return nil, err
+	}
+
+	if t.ipv4 {
+		if err := internal.SetIPv4Address(t.name, config.AppConfig.IPv4, "255.255.255.255"); err != nil {
+			return nil, fmt.Errorf("failed to set IPv4 address: %v", err)
+		}
+		if err := internal.SetIPv4MTU(t.name, t.mtu); err != nil {
+			return nil, fmt.Errorf("failed to set IPv4 MTU: %v", err)
+		}
+	}
+
+	if t.ipv6 {
+		if err := internal.SetIPv6Address(t.name, config.AppConfig.IPv6, "128"); err != nil {
+			return nil, fmt.Errorf("failed to set IPv6 address: %v", err)
+		}
+		if err := internal.SetIPv6MTU(t.name, t.mtu); err != nil {
+			return nil, fmt.Errorf("failed to set IPv6 MTU: %v", err)
+		}
+	}
+
+	if err := internal.SetInterfaceUp(t.name); err != nil {
+		return nil, fmt.Errorf("failed to bring interface up: %v", err)
+	}
+
+	return api.NewNetstackAdapterWithOffset(dev, darwinTunOffset), nil
+}

--- a/cmd/nativetun_default.go
+++ b/cmd/nativetun_default.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package cmd
 

--- a/internal/utils_darwin.go
+++ b/internal/utils_darwin.go
@@ -1,0 +1,69 @@
+//go:build darwin
+
+package internal
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os/exec"
+)
+
+// SetIPv4Address assigns a point-to-point IPv4 address to a utun interface via
+// ifconfig. macOS needs the peer/destination set and an explicit prefix; a bare
+// address otherwise defaults to a classful mask (e.g. /16) that breaks routing.
+func SetIPv4Address(ifaceName, ipAddr, mask string) error {
+	prefix := 32
+	if m := net.IPMask(net.ParseIP(mask).To4()); m != nil {
+		if ones, bits := m.Size(); bits == 32 {
+			prefix = ones
+		}
+	}
+	// utun is point-to-point: local and peer are the same tunnel address.
+	cmd := exec.Command("ifconfig", ifaceName, "inet",
+		fmt.Sprintf("%s/%d", ipAddr, prefix), ipAddr, "alias")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", output)
+	}
+
+	log.Println("IPv4 address set successfully:", ipAddr)
+	return nil
+}
+
+func SetIPv6Address(ifaceName, ipAddr, mask string) error {
+	cmd := exec.Command("ifconfig", ifaceName, "inet6", ipAddr, "prefixlen", mask, "alias")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", output)
+	}
+
+	log.Println("IPv6 address set successfully:", ipAddr)
+	return nil
+}
+
+// SetIPv4MTU sets the interface MTU. On macOS the MTU is per-interface (not
+// per-address-family), so SetIPv6MTU is an alias for this.
+func SetIPv4MTU(ifaceName string, mtu int) error {
+	cmd := exec.Command("ifconfig", ifaceName, "mtu", fmt.Sprintf("%d", mtu))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", output)
+	}
+
+	log.Println("MTU set successfully:", mtu)
+	return nil
+}
+
+func SetIPv6MTU(ifaceName string, mtu int) error {
+	return SetIPv4MTU(ifaceName, mtu)
+}
+
+func SetInterfaceUp(ifaceName string) error {
+	cmd := exec.Command("ifconfig", ifaceName, "up")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", output)
+	}
+	return nil
+}


### PR DESCRIPTION
macOS was the only major platform without `nativetun`. This adds a darwin implementation so macOS gets a real utun interface carrying raw IPv4/IPv6 — including UDP (QUIC/HTTP-3, WebRTC, plain DNS), which the SOCKS5 proxy path does not always.

macOS utun devices prepend a 4-byte address-family header, so NetstackAdapter gains an optional read/write offset (NewNetstackAdapterWithOffset) — the same mechanism the FreeBSD native-tun proposal in #106 uses (can be reused by BSDs). The offset-0 path is untouched, so Linux/Windows/SOCKS behaviour is identical (covered by a new test).

- api/tunnel.go: NetstackAdapter packet-headroom/offset support (+ api test)
- cmd/nativetun_darwin.go: darwin create() (utun via wireguard-go/tun, offset 4)
- internal/utils_darwin.go: ifconfig(8) address/MTU helpers (mirrors utils_windows.go)
- cmd/nativetun_default.go: exclude darwin from the unsupported stub
- README: macOS build/run/routes sections

Tested on macOS 26 (Apple Silicon): TCP + UDP correct, DNS, 50MB integrity, 60-way concurrency, ~280 Mbit/s to Cloudflare — competitive with the official client. LLM is used to create and test the code, however, it's been reviewed by me properly and tested on device for a good while and I'm running it currently.

Update: I've build https://github.com/surendrajat/cfwarpd on top of `usque` and [`dnsproxy`](https://github.com/AdguardTeam/dnsproxy) to support a custom DNS (NextDNS) alongside warp tunnel. In case someone finds it useful. It's macOS only for now.