### PR TITLE
security: add speculation store bypass mitigation

### DIFF
--- a/internal/speculation.go
+++ b/internal/speculation.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+)
+
+type speculationControlArgsValues struct {
+	option   uintptr
+	suboption uintptr
+	disable  uintptr
+}
+
+func speculationControlArgs() speculationControlArgsValues {
+	return speculationControlArgsValues{option: 53, suboption: 0, disable: 4}
+}
+
+func EnableSpeculationStoreBypassMitigation() error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	args := speculationControlArgs()
+	_, _, errno := syscall.RawSyscall6(syscall.SYS_PRCTL, args.option, args.suboption, args.disable, 0, 0, 0)
+	if errno != 0 {
+		return errors.New(errno.Error())
+	}
+
+	return nil
+}

--- a/internal/speculation_test.go
+++ b/internal/speculation_test.go
@@ -1,0 +1,9 @@
+package internal
+
+import "testing"
+
+func TestSpeculationControlArgs(t *testing.T) {
+	if got, want := speculationControlArgs(), (speculationControlArgsValues{option: 53, suboption: 0, disable: 4}); got != want {
+		t.Fatalf("unexpected speculation control args: got %#v want %#v", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,9 +5,14 @@ import (
 	"os"
 
 	"github.com/Diniboy1123/usque/cmd"
+	"github.com/Diniboy1123/usque/internal"
 )
 
 func main() {
+	if err := internal.EnableSpeculationStoreBypassMitigation(); err != nil {
+		fmt.Println("Warning: failed to enable speculation store bypass mitigation:", err)
+	}
+
 	if err := cmd.Execute(); err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- add a Linux startup mitigation for speculation store bypass using prctl
- keep the change non-blocking and portable for non-Linux builds
- add a regression test for the mitigation helper

## Verification
- go test ./internal ./...